### PR TITLE
Add error checks for binary.Read

### DIFF
--- a/binReader.go
+++ b/binReader.go
@@ -8,13 +8,17 @@ import (
 )
 
 // Read string length, then the string
-func ReadString(w io.Reader) string {
+func ReadString(w io.Reader) (string, error) {
 	var stringLength uint16
-	binary.Read(w, binary.LittleEndian, &stringLength)
+	if err := binary.Read(w, binary.LittleEndian, &stringLength); err != nil {
+		return "", err
+	}
 	stringData := make([]byte, stringLength)
-	binary.Read(w, binary.LittleEndian, &stringData)
+	if err := binary.Read(w, binary.LittleEndian, &stringData); err != nil {
+		return "", err
+	}
 
-	return string(stringData)
+	return string(stringData), nil
 }
 
 type BinReader struct {


### PR DESCRIPTION
## Summary
- return an error from `ReadString`
- verify `binary.Read` calls in `extract.go`

## Testing
- `go build ./...`
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840df2f6814832a9ed19f2856b53cc5