### PR TITLE
Prevent overwrite when extracting without -f

### DIFF
--- a/archive_test.go
+++ b/archive_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHandleFileNoOverwriteWithoutForce(t *testing.T) {
+	tmpDir := t.TempDir()
+	dest := tmpDir + string(os.PathSeparator)
+	existing := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(existing, []byte("old"), 0644); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	doForce = false
+	archivePath = "" // not used when open fails
+	entry := &FileEntry{Path: "test.txt", Offset: 1}
+
+	err := handleFile(dest, 0, entry)
+	if err == nil {
+		t.Fatalf("expected error when file exists without force")
+	}
+
+	data, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+	if string(data) != "old" {
+		t.Fatalf("file should not be overwritten")
+	}
+}

--- a/extract.go
+++ b/extract.go
@@ -181,13 +181,25 @@ func extract(destinations []string, listOnly bool) {
 			wg.Add()
 			go func(item *FileEntry) {
 				defer wg.Done()
-				handleFile(destination, lfeat, item)
+				if err := handleFile(destination, lfeat, item); err != nil {
+					if doForce {
+						doLog(false, "Unable to open file: %v :: %v", item.Path, err)
+					} else {
+						log.Fatalf("Unable to open file: %v :: %v", item.Path, err)
+					}
+				}
 			}(&fileList[f])
 		}
 		wg.Wait()
 	} else {
 		for f := range fileList {
-			handleFile(destination, lfeat, &fileList[f])
+			if err := handleFile(destination, lfeat, &fileList[f]); err != nil {
+				if doForce {
+					doLog(false, "Unable to open file: %v :: %v", fileList[f].Path, err)
+				} else {
+					log.Fatalf("Unable to open file: %v :: %v", fileList[f].Path, err)
+				}
+			}
 		}
 	}
 
@@ -196,10 +208,10 @@ func extract(destinations []string, listOnly bool) {
 	}
 }
 
-func handleFile(destination string, lfeat BitFlags, item *FileEntry) {
+func handleFile(destination string, lfeat BitFlags, item *FileEntry) error {
 	if item.Offset == 0 {
 		skippedFiles.Add(1)
-		return
+		return nil
 	}
 	var err error
 	//Make directories
@@ -224,14 +236,10 @@ func handleFile(destination string, lfeat BitFlags, item *FileEntry) {
 			os.Chmod(destination+item.Path, filePerm)
 		}
 	} else {
-		newFile, err = os.OpenFile(destination+item.Path, os.O_CREATE|os.O_WRONLY, filePerm)
+		newFile, err = os.OpenFile(destination+item.Path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, filePerm)
 	}
 	if err != nil {
-		if doForce {
-			doLog(false, "Unable to open file: %v :: %v", item.Path, err)
-		} else {
-			log.Fatalf("Unable to open file: %v :: %v", item.Path, err)
-		}
+		return err
 	}
 
 	//Seek to data in archive
@@ -263,7 +271,7 @@ func handleFile(destination string, lfeat BitFlags, item *FileEntry) {
 			} else {
 				log.Fatalf("gzip error: Unable to create reader: %v :: %v", item.Path, err)
 			}
-			return
+			return nil
 		}
 		defer gzReader.Close()
 		src = gzReader
@@ -304,4 +312,5 @@ func handleFile(destination string, lfeat BitFlags, item *FileEntry) {
 			}
 		}
 	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- fail opening files if they already exist when force is not used
- propagate `handleFile` open errors to callers
- add unit test for no-overwrite behaviour

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684111e8051c832aa30c64385afa70cf