### PR TITLE
Handle BufferedFile close errors

### DIFF
--- a/bufferWrite_test.go
+++ b/bufferWrite_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"testing"
+)
+
+// errWriter always returns an error on Write
+type errWriter struct{}
+
+func (errWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("write error")
+}
+
+func TestBufferedFileClosePropagatesError(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "bf")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	bf := &BufferedFile{
+		file:   f,
+		writer: bufio.NewWriterSize(errWriter{}, 32),
+	}
+	bf.writer.WriteByte('a')
+	if err := bf.Close(); err == nil {
+		t.Fatal("expected close error, got nil")
+	}
+}

--- a/create.go
+++ b/create.go
@@ -56,7 +56,9 @@ func create(inputPaths []string) error {
 		log.Fatalf("create: os.Create: %v", err)
 	}
 
-	bf.Close()
+	if err := bf.Close(); err != nil {
+		log.Fatalf("create: close failed: %v", err)
+	}
 	doLog(false, "\nWrote %v, %v containing %v files.", archivePath, humanize.Bytes(uint64(info.Size())), len(files))
 	return nil
 }

--- a/extract.go
+++ b/extract.go
@@ -291,7 +291,9 @@ func handleFile(destination string, lfeat BitFlags, item *FileEntry) {
 			log.Fatalf("Unable to write data to file: %v :: %v", item.Path, err)
 		}
 	}
-	bf.Close()
+	if err := bf.Close(); err != nil {
+		log.Fatalf("extract: close failed: %v", err)
+	}
 
 	if lfeat.IsSet(fChecksums) {
 		if bytes.Equal(hashSum, expectedChecksum) {


### PR DESCRIPTION
## Summary
- capture errors returned from `bf.Close()` in `create.go` and `extract.go`
- add unit test using an erroring writer to verify `BufferedFile.Close` propagates failures

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684111edbe98832aa5af333cdb895027