### PR TITLE
Handle mkdir failure

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -171,7 +171,14 @@ func extract(destinations []string, listOnly bool) {
 		if lfeat.IsSet(fPermissions) {
 			perms = item.Mode
 		}
-		os.MkdirAll(item.Path, perms)
+		if err := os.MkdirAll(item.Path, perms); err != nil {
+			if doForce {
+				doLog(false, "Unable to create directory: %v :: %v", item.Path, err)
+				continue
+			} else {
+				log.Fatalf("Unable to create directory: %v :: %v", item.Path, err)
+			}
+		}
 	}
 	arc.Close()
 
@@ -204,7 +211,14 @@ func handleFile(destination string, lfeat BitFlags, item *FileEntry) {
 	var err error
 	//Make directories
 	dir := path.Dir(destination + item.Path)
-	os.MkdirAll(dir, os.ModePerm)
+	if err = os.MkdirAll(dir, os.ModePerm); err != nil {
+		if doForce {
+			doLog(false, "Unable to create directory: %v :: %v", dir, err)
+			return
+		} else {
+			log.Fatalf("Unable to create directory: %v :: %v", dir, err)
+		}
+	}
 
 	//Set file perms, if needed
 	filePerm := os.FileMode(0644)

--- a/extract_test.go
+++ b/extract_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHandleFileDirCreationFailure(t *testing.T) {
+	tmp := t.TempDir()
+
+	// create a file that will act as the destination root
+	destFile := filepath.Join(tmp, "destfile")
+	if err := os.WriteFile(destFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("setup dest file: %v", err)
+	}
+
+	archivePath = filepath.Join(tmp, "dummy.goxa")
+	if err := os.WriteFile(archivePath, []byte{}, 0644); err != nil {
+		t.Fatalf("setup archive: %v", err)
+	}
+
+	doForce = true
+	defer func() { doForce = false }()
+
+	item := FileEntry{Path: filepath.Join("sub", "file.txt"), Offset: 1}
+
+	handleFile(destFile+string(os.PathSeparator), 0, &item)
+
+	if _, err := os.Stat(filepath.Join(tmp, "destfile", "sub")); err == nil {
+		t.Fatalf("directory should not be created")
+	}
+}


### PR DESCRIPTION
## Summary
- abort extraction on directory creation failure and log if forced
- add regression test for failing directory creation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684111f17844832ab3113329e25014d7