### PR TITLE
Handle partial writes in WriteString

### DIFF
--- a/countWriter.go
+++ b/countWriter.go
@@ -5,9 +5,20 @@ import (
 	"io"
 )
 
-func WriteString(w io.Writer, s string) {
-	binary.Write(w, binary.LittleEndian, uint16(len(s)))
-	w.Write([]byte(s))
+func WriteString(w io.Writer, s string) error {
+	if err := binary.Write(w, binary.LittleEndian, uint16(len(s))); err != nil {
+		return err
+	}
+
+	data := []byte(s)
+	for len(data) > 0 {
+		n, err := w.Write(data)
+		if err != nil {
+			return err
+		}
+		data = data[n:]
+	}
+	return nil
 }
 
 // a tiny io.Writer that counts bytes passed through

--- a/countWriter_test.go
+++ b/countWriter_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+)
+
+type shortWriter struct {
+	w   io.Writer
+	max int
+}
+
+func (sw *shortWriter) Write(p []byte) (int, error) {
+	if len(p) > sw.max {
+		p = p[:sw.max]
+	}
+	return sw.w.Write(p)
+}
+
+func TestWriteStringNormal(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteString(&buf, "hello"); err != nil {
+		t.Fatalf("WriteString returned error: %v", err)
+	}
+	want := make([]byte, 2)
+	binary.LittleEndian.PutUint16(want, uint16(len("hello")))
+	want = append(want, []byte("hello")...)
+	if !bytes.Equal(buf.Bytes(), want) {
+		t.Errorf("unexpected output: %v", buf.Bytes())
+	}
+}
+
+func TestWriteStringShortWrite(t *testing.T) {
+	var underlying bytes.Buffer
+	sw := &shortWriter{w: &underlying, max: 2}
+	if err := WriteString(sw, "hello"); err != nil {
+		t.Fatalf("WriteString returned error: %v", err)
+	}
+	want := make([]byte, 2)
+	binary.LittleEndian.PutUint16(want, uint16(len("hello")))
+	want = append(want, []byte("hello")...)
+	if !bytes.Equal(underlying.Bytes(), want) {
+		t.Errorf("unexpected output with short writer: %v", underlying.Bytes())
+	}
+}

--- a/create.go
+++ b/create.go
@@ -81,7 +81,9 @@ func writeHeader(emptyDirs, files []FileEntry) (uint64, []byte) {
 		if features&fModDates != 0 {
 			binary.Write(&header, binary.LittleEndian, int64(folder.ModTime.Unix()))
 		}
-		WriteString(&header, folder.Path)
+		if err := WriteString(&header, folder.Path); err != nil {
+			log.Fatalf("WriteString failed: %v", err)
+		}
 	}
 
 	//File info
@@ -94,7 +96,9 @@ func writeHeader(emptyDirs, files []FileEntry) (uint64, []byte) {
 		if features&fModDates != 0 {
 			binary.Write(&header, binary.LittleEndian, int64(file.ModTime.Unix()))
 		}
-		WriteString(&header, file.Path)
+		if err := WriteString(&header, file.Path); err != nil {
+			log.Fatalf("WriteString failed: %v", err)
+		}
 	}
 
 	//Save end of header, so we can update offsets later


### PR DESCRIPTION
## Summary
- write all bytes in `WriteString` and surface errors
- check errors when writing strings in the header
- add tests for normal and short-write cases

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684111f509d4832ab05a1c82efe7c376