### PR TITLE
Fix relative path archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,20 @@ goxa [mode][options] -arc=archiveFile [additional arguments]
 | `v` | Verbose logging |
 | `f` | Force overwrite existing files / ignore read errors |
 
+Paths are stored relative to the given inputs by default. Use `a` when
+extracting to write files to their original absolute locations. If `a` is not
+specified for extraction, any absolute paths in the archive are recreated under
+the chosen destination directory.
+
 ### Additional Global Flags
 
 | Flag | Description |
 |------|-------------|
 | `-arc=` | Specify archive file name |
 | `-stdout` | Output archive to stdout |
-| `-progress=false` | Disable progress bar display |
+| `-progress=false` | Disable progress display |
+
+Progress output shows transfer speed and the current file being processed.
 
 ### Examples
 

--- a/archive_test.go
+++ b/archive_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+type fileSpec struct {
+	rel  string
+	data []byte
+	perm fs.FileMode
+}
+
+func setupTestTree(t *testing.T, root string) []fileSpec {
+	old := syscall.Umask(0)
+	defer syscall.Umask(old)
+	files := []fileSpec{
+		{rel: "dir1/file1.txt", data: []byte("file1"), perm: 0o754},
+		{rel: "dir1/.hidden", data: []byte("hidden1"), perm: 0o600},
+		{rel: "dir2/file2.txt", data: []byte("file2"), perm: 0o640},
+		{rel: ".hiddendir/hfile.txt", data: []byte("hidden2"), perm: 0o600},
+		{rel: "rootfile.txt", data: []byte("root"), perm: 0o664},
+	}
+
+	for _, f := range files {
+		full := filepath.Join(root, f.rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, f.data, f.perm); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	return files
+}
+
+func checkFile(t *testing.T, path string, expect []byte, perm fs.FileMode, checkPerm bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %v: %v", path, err)
+	}
+	if !bytes.Equal(data, expect) {
+		t.Fatalf("content mismatch for %v", path)
+	}
+	if checkPerm {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %v: %v", path, err)
+		}
+		if info.Mode().Perm() != perm {
+			t.Fatalf("perm mismatch for %v: got %o want %o", path, info.Mode().Perm(), perm)
+		}
+	}
+}
+
+func TestArchiveScenarios(t *testing.T) {
+	cases := []struct {
+		name         string
+		createFlags  BitFlags
+		extractFlags BitFlags
+		expectHidden bool
+		checkPerms   bool
+	}{
+		{"rel_compress", 0, 0, false, false},
+		{"rel_nocompress", fNoCompress, 0, false, false},
+		{"rel_invis", fIncludeInvis, 0, true, false},
+		{"abs_compress", fAbsolutePaths, fAbsolutePaths, false, false},
+		{"abs_nocompress", fAbsolutePaths | fNoCompress, fAbsolutePaths, false, false},
+		{"abs_invis", fAbsolutePaths | fIncludeInvis, fAbsolutePaths, true, false},
+		{"rel_all_flags", fPermissions | fChecksums | fIncludeInvis | fNoCompress, 0, true, true},
+		{"abs_all_flags", fAbsolutePaths | fPermissions | fChecksums | fIncludeInvis | fNoCompress, fAbsolutePaths, true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			root := filepath.Join(tempDir, "root")
+			specs := setupTestTree(t, root)
+
+			var oldUmask int
+			if tc.checkPerms {
+				oldUmask = syscall.Umask(0)
+				defer syscall.Umask(oldUmask)
+			}
+
+			archivePath = filepath.Join(tempDir, "test.goxa")
+			toStdOut = false
+			doForce = false
+			features = tc.createFlags
+
+			cwd, _ := os.Getwd()
+			os.Chdir(tempDir)
+			defer os.Chdir(cwd)
+
+			if err := create([]string{root}); err != nil {
+				t.Fatalf("create failed: %v", err)
+			}
+
+			os.RemoveAll(root)
+			features = tc.extractFlags
+
+			var dest string
+			if tc.extractFlags.IsSet(fAbsolutePaths) {
+				extract([]string{}, false)
+			} else {
+				dest = filepath.Join(tempDir, "out")
+				if err := os.MkdirAll(dest, 0o755); err != nil {
+					t.Fatalf("mkdir dest: %v", err)
+				}
+				extract([]string{dest}, false)
+			}
+
+			var base string
+			if tc.extractFlags.IsSet(fAbsolutePaths) {
+				base = root
+			} else {
+				base = filepath.Join(dest, filepath.Base(root))
+			}
+
+			for _, sp := range specs {
+				hidden := strings.Contains("/"+sp.rel, "/.")
+				if hidden && !tc.expectHidden {
+					if _, err := os.Stat(filepath.Join(base, sp.rel)); !os.IsNotExist(err) {
+						t.Fatalf("hidden file should not exist: %v", sp.rel)
+					}
+					continue
+				}
+				checkFile(t, filepath.Join(base, sp.rel), sp.data, sp.perm, tc.checkPerms)
+			}
+		})
+	}
+}
+
+func TestArchiveParentRelative(t *testing.T) {
+	tempDir := t.TempDir()
+	parent := filepath.Join(tempDir, "parent")
+	root := filepath.Join(parent, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := []byte("hi")
+	if err := os.WriteFile(filepath.Join(root, "file.txt"), data, 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	work := filepath.Join(tempDir, "work")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatalf("mkdir work: %v", err)
+	}
+
+	archivePath = filepath.Join(tempDir, "test.goxa")
+	features = 0
+	toStdOut = false
+	doForce = false
+
+	cwd, _ := os.Getwd()
+	os.Chdir(work)
+	defer os.Chdir(cwd)
+
+	relRoot, _ := filepath.Rel(work, root)
+	if err := create([]string{relRoot}); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	os.RemoveAll(root)
+	dest := filepath.Join(tempDir, "out")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+	extract([]string{dest}, false)
+
+	extracted := filepath.Join(dest, filepath.Base(root), "file.txt")
+	checkFile(t, extracted, data, 0o644, false)
+}

--- a/binReader.go
+++ b/binReader.go
@@ -1,20 +1,28 @@
 package main
 
 import (
-	"bufio"
-	"encoding/binary"
-	"io"
-	"os"
+        "bufio"
+        "encoding/binary"
+        "fmt"
+        "io"
+        "os"
+        "unicode/utf8"
 )
 
 // Read string length, then the string
-func ReadString(w io.Reader) string {
-	var stringLength uint16
-	binary.Read(w, binary.LittleEndian, &stringLength)
-	stringData := make([]byte, stringLength)
-	binary.Read(w, binary.LittleEndian, &stringData)
-
-	return string(stringData)
+func ReadString(w io.Reader) (string, error) {
+        var stringLength uint16
+        if err := binary.Read(w, binary.LittleEndian, &stringLength); err != nil {
+                return "", err
+        }
+        stringData := make([]byte, stringLength)
+        if _, err := io.ReadFull(w, stringData); err != nil {
+                return "", err
+        }
+        if !utf8.Valid(stringData) {
+                return "", fmt.Errorf("invalid UTF-8 string")
+        }
+        return string(stringData), nil
 }
 
 type BinReader struct {

--- a/countReader.go
+++ b/countReader.go
@@ -1,0 +1,17 @@
+package main
+
+import "io"
+
+// countingReader wraps an io.Reader and increments progress current count.
+type countingReader struct {
+	r io.Reader
+	p *progressData
+}
+
+func (cr countingReader) Read(b []byte) (int, error) {
+	n, err := cr.r.Read(b)
+	if cr.p != nil {
+		cr.p.current.Add(int64(n))
+	}
+	return n, err
+}

--- a/countWriter.go
+++ b/countWriter.go
@@ -1,13 +1,21 @@
 package main
 
 import (
-	"encoding/binary"
-	"io"
+        "encoding/binary"
+        "fmt"
+        "io"
 )
 
-func WriteString(w io.Writer, s string) {
-	binary.Write(w, binary.LittleEndian, uint16(len(s)))
-	w.Write([]byte(s))
+func WriteString(w io.Writer, s string) error {
+        b := []byte(s)
+        if len(b) > 0xFFFF {
+                return fmt.Errorf("string too long: %d bytes", len(b))
+        }
+        if err := binary.Write(w, binary.LittleEndian, uint16(len(b))); err != nil {
+                return err
+        }
+        _, err := w.Write(b)
+        return err
 }
 
 // a tiny io.Writer that counts bytes passed through

--- a/struct.go
+++ b/struct.go
@@ -14,6 +14,7 @@ var (
 type FileEntry struct {
 	Offset  uint64
 	Path    string
+	SrcPath string
 	Size    uint64
 	Mode    fs.FileMode
 	ModTime time.Time

--- a/unicode_test.go
+++ b/unicode_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUnicodeFilenames(t *testing.T) {
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "ユニコード")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	fileName := "文件.txt"
+	filePath := filepath.Join(root, fileName)
+	content := []byte("hello unicode")
+	if err := os.WriteFile(filePath, content, 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	archivePath = filepath.Join(tempDir, "test.goxa")
+	features = 0
+	toStdOut = false
+	doForce = false
+
+	cwd, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(cwd)
+
+	if err := create([]string{root}); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	dest := filepath.Join(tempDir, "out")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("failed to create dest: %v", err)
+	}
+
+	extract([]string{dest}, false)
+
+	extracted := filepath.Join(dest, filepath.Base(root), fileName)
+	data, err := os.ReadFile(extracted)
+	if err != nil {
+		t.Fatalf("failed to read extracted file: %v", err)
+	}
+	if !bytes.Equal(data, content) {
+		t.Fatalf("content mismatch")
+	}
+}

--- a/util.go
+++ b/util.go
@@ -67,8 +67,94 @@ func doLog(verbose bool, format string, args ...interface{}) {
 	}
 }
 
+// safeJoin joins base and target, ensuring the result stays within base and
+// does not escape via symlinks that already exist on disk.
+func safeJoin(base, target string) (string, error) {
+	cleanBase := filepath.Clean(base)
+	cleanTarget := filepath.Clean(target)
+
+	if filepath.IsAbs(cleanTarget) {
+		cleanTarget = strings.TrimPrefix(cleanTarget, string(os.PathSeparator))
+	}
+
+	joined := filepath.Join(cleanBase, cleanTarget)
+	joined = filepath.Clean(joined)
+
+	prefix := cleanBase + string(os.PathSeparator)
+	if joined != cleanBase && !strings.HasPrefix(joined, prefix) {
+		return "", fmt.Errorf("illegal path: %s", target)
+	}
+
+	rel, err := filepath.Rel(cleanBase, joined)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(rel, string(os.PathSeparator))
+	cur := cleanBase
+	for _, part := range parts {
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if err != nil {
+			if os.IsNotExist(err) {
+				break
+			}
+			return "", err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("symlink traversal detected: %s", cur)
+		}
+	}
+
+	return joined, nil
+}
+
+// storedPath returns the archived path for fullPath based on root and the
+// fAbsolutePaths flag. When absolute paths are disabled, paths are stored
+// relative to the provided root's basename.
+func storedPath(root, fullPath string) string {
+	cleanFull := filepath.Clean(fullPath)
+
+	if features.IsSet(fAbsolutePaths) {
+		if filepath.IsAbs(cleanFull) {
+			return cleanFull
+		}
+		abs, err := filepath.Abs(cleanFull)
+		if err == nil {
+			return abs
+		}
+		return cleanFull
+	}
+
+	cleanRoot := filepath.Clean(root)
+	base := filepath.Base(cleanRoot)
+	if base == "." {
+		base = ""
+	}
+
+	rel, err := filepath.Rel(cleanRoot, cleanFull)
+	if err != nil {
+		rel = filepath.Base(cleanFull)
+	}
+	if rel == "." {
+		rel = ""
+	}
+
+	if base == "" {
+		return filepath.Clean(rel)
+	}
+
+	if rel == "" {
+		return filepath.Clean(base)
+	}
+
+	return filepath.Join(base, rel)
+}
+
 func walkPaths(roots []string) (dirs []FileEntry, files []FileEntry, err error) {
-	type dirState struct{ entryCount int }
+	type dirState struct {
+		entryCount int
+		info       os.FileInfo
+	}
 	states := make(map[string]*dirState)
 
 	for _, root := range roots {
@@ -76,21 +162,19 @@ func walkPaths(roots []string) (dirs []FileEntry, files []FileEntry, err error) 
 		if err != nil {
 			return nil, nil, err
 		}
+		root = filepath.Clean(root)
 
 		// File case
 		if !info.IsDir() {
 			if features.IsSet(fIncludeInvis) || !strings.HasPrefix(info.Name(), ".") {
-				metaData := gatherMeta(root, info)
-
-				if metaData.Mode&os.ModeSymlink != 0 {
-					files = append(files, metaData)
-				}
+				metaData := gatherMeta(storedPath(root, root), root, info)
+				files = append(files, metaData)
 			}
 			continue
 		}
 
 		// Directory case
-		states[root] = &dirState{}
+		states[storedPath(root, root)] = &dirState{info: info}
 		err = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 			if walkErr != nil {
 				return walkErr
@@ -107,19 +191,23 @@ func walkPaths(roots []string) (dirs []FileEntry, files []FileEntry, err error) 
 				return nil
 			}
 
-			parent := filepath.Dir(path)
-			if st, ok := states[parent]; ok {
+			parentKey := storedPath(root, filepath.Dir(path))
+			if st, ok := states[parentKey]; ok {
 				st.entryCount++
 			}
 
 			if d.IsDir() {
-				states[path] = &dirState{}
+				info, err := d.Info()
+				if err != nil {
+					return err
+				}
+				states[storedPath(root, path)] = &dirState{info: info}
 			} else {
 				info, err := d.Info()
 				if err != nil {
 					return err
 				}
-				files = append(files, gatherMeta(path, info))
+				files = append(files, gatherMeta(storedPath(root, path), path, info))
 			}
 			return nil
 		})
@@ -131,11 +219,7 @@ func walkPaths(roots []string) (dirs []FileEntry, files []FileEntry, err error) 
 	// Collect only those dirs with zero entries
 	for path, st := range states {
 		if st.entryCount == 0 {
-			info, err := os.Stat(path)
-			if err != nil {
-				return nil, nil, err
-			}
-			dirs = append(dirs, gatherMeta(path, info))
+			dirs = append(dirs, gatherMeta(path, path, st.info))
 		}
 	}
 
@@ -147,9 +231,10 @@ func walkPaths(roots []string) (dirs []FileEntry, files []FileEntry, err error) 
 }
 
 // gatherMeta pulls the common metadata for a path.
-func gatherMeta(path string, info os.FileInfo) FileEntry {
+func gatherMeta(path, src string, info os.FileInfo) FileEntry {
 	entry := FileEntry{
 		Path:    path,
+		SrcPath: src,
 		Size:    uint64(info.Size()),
 		ModTime: info.ModTime(),
 	}


### PR DESCRIPTION
## Summary
- keep the original path when walking inputs
- use that stored path when opening files during archive creation
- add regression test for archiving a directory above the working dir

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840df2f6814832a9ed19f2856b53cc5