### PR TITLE
Fix file leaks on extraction errors

### DIFF
--- a/countWriter.go
+++ b/countWriter.go
@@ -1,21 +1,28 @@
 package main
 
 import (
-        "encoding/binary"
-        "fmt"
-        "io"
+	"encoding/binary"
+	"fmt"
+	"io"
 )
 
 func WriteString(w io.Writer, s string) error {
-        b := []byte(s)
-        if len(b) > 0xFFFF {
-                return fmt.Errorf("string too long: %d bytes", len(b))
-        }
-        if err := binary.Write(w, binary.LittleEndian, uint16(len(b))); err != nil {
-                return err
-        }
-        _, err := w.Write(b)
-        return err
+	b := []byte(s)
+	if len(b) > 0xFFFF {
+		return fmt.Errorf("string too long: %d bytes", len(b))
+	}
+	if err := binary.Write(w, binary.LittleEndian, uint16(len(b))); err != nil {
+		return err
+	}
+
+	for len(b) > 0 {
+		n, err := w.Write(b)
+		b = b[n:]
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // a tiny io.Writer that counts bytes passed through

--- a/extract_test.go
+++ b/extract_test.go
@@ -25,7 +25,7 @@ func TestHandleFileDirCreationFailure(t *testing.T) {
 
 	item := FileEntry{Path: filepath.Join("sub", "file.txt"), Offset: 1}
 
-	handleFile(destFile+string(os.PathSeparator), 0, &item)
+	_ = handleFile(destFile+string(os.PathSeparator), 0, &item, &progressData{})
 
 	if _, err := os.Stat(filepath.Join(tmp, "destfile", "sub")); err == nil {
 		t.Fatalf("directory should not be created")

--- a/util.go
+++ b/util.go
@@ -146,7 +146,7 @@ func walkPaths(roots []string) (dirs []FileEntry, files []FileEntry, err error) 
 		// File case
 		if !info.IsDir() {
 			if features.IsSet(fIncludeInvis) || !strings.HasPrefix(info.Name(), ".") {
-				metaData := gatherMeta(storedPath(root, root), info)
+				metaData := gatherMeta(storedPath(root, root), root, info)
 				files = append(files, metaData)
 			}
 			continue
@@ -186,7 +186,7 @@ func walkPaths(roots []string) (dirs []FileEntry, files []FileEntry, err error) 
 				if err != nil {
 					return err
 				}
-				files = append(files, gatherMeta(storedPath(root, path), info))
+				files = append(files, gatherMeta(storedPath(root, path), path, info))
 			}
 			return nil
 		})
@@ -198,7 +198,7 @@ func walkPaths(roots []string) (dirs []FileEntry, files []FileEntry, err error) 
 	// Collect only those dirs with zero entries
 	for path, st := range states {
 		if st.entryCount == 0 {
-			dirs = append(dirs, gatherMeta(path, st.info))
+			dirs = append(dirs, gatherMeta(path, path, st.info))
 		}
 	}
 


### PR DESCRIPTION
## Summary
- ensure open files are closed when extraction failures occur

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6841186dd0a0832aaa4f5fa88a9a121b