### PR TITLE
Fix progress display line clearing

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -108,15 +108,17 @@ func printProgress(p *progressData) {
 
 	fileName, _ := p.file.Load().(string)
 	fileName = filepath.Base(fileName)
+
 	// Format output (80 columns max)
-	out := fmt.Sprintf("\r%s %3.2f%% %v/s %s", bar, progress*100, humanize.Bytes(uint64(speed)), fileName)
+	out := fmt.Sprintf("%s %3.2f%% %v/s %s", bar, progress*100, humanize.Bytes(uint64(speed)), fileName)
 	if len(out) > 80 {
 		out = out[:80]
 	}
 
 	// Print only if changed (reduce flicker)
 	if out != p.lastPrintStr {
-		fmt.Print(out)
+		// Clear the previous line before printing the new progress
+		fmt.Printf("\r\033[K%s", out)
 		p.lastPrintStr = out
 	}
 }


### PR DESCRIPTION
## Summary
- clear previous progress line before drawing new output

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68412f8b02d4832a926edfb262650572