### PR TITLE
Fix progress display line clearing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/klauspost/pgzip v1.2.6
 	github.com/remeh/sizedwaitgroup v1.0.0
 	golang.org/x/crypto v0.38.0
+	golang.org/x/term v0.32.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -10,3 +10,5 @@ golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
 golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
+golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=


### PR DESCRIPTION
## Summary
- clear previous progress line before drawing new output
- adapt progress output to terminal width

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68412f8b02d4832a926edfb262650572