### PR TITLE
Remove unused block-related fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ GoXA is a gopher-friendly archiver written in Go. It's quick and simple, and sti
 - [x] Empty directory support
 - [x] Fully documented binary format ([file-format.md](file-format.md))
 - [x] Optional support for symlinks and other special files
-- [x] Clean, dependency-free Go code
+- [x] Clean Go code with minimal dependencies
 
 ## File Format
 
@@ -21,7 +21,7 @@ See [file-format.md](file-format.md) for the full binary format.
 
 ## Install
 
-With Go 1.20+:
+With Go 1.24+:
 
 ```bash
 go install github.com/Distortions81/goXA@latest
@@ -67,6 +67,7 @@ Paths default to relative. Using `a` when extracting restores absolute paths.
 |------|-------------|
 | `-arc=` | Archive file name |
 | `-stdout` | Output archive to stdout |
+| `-files` | Comma-separated list of files and directories to extract |
 | `-progress=false` | Disable progress display |
 
 Progress shows transfer speed and the current file being processed.

--- a/const.go
+++ b/const.go
@@ -8,9 +8,6 @@ const (
 	writeBuffer        = readBuffer
 	defaultArchiveName = "archive.goxa"
 	checksumSize       = 32
-
-	//Threading
-	blockSize = 1000 * 1000 * 1 //MiB
 )
 
 // Features

--- a/struct.go
+++ b/struct.go
@@ -21,8 +21,4 @@ type FileEntry struct {
 	Size     uint64
 	Mode     fs.FileMode
 	ModTime  time.Time
-
-	//Block mode
-	NumBlocks   uint64
-	BlockOffset []uint64
 }

--- a/util.go
+++ b/util.go
@@ -4,15 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
 	"time"
-
-	"golang.org/x/crypto/blake2b"
 )
 
 func fileExists(filePath string) (bool, error) {
@@ -29,20 +26,6 @@ func fileExists(filePath string) (bool, error) {
 func removeExtension(filename string) string {
 	extension := filepath.Ext(filename)
 	return filename[:len(filename)-len(extension)]
-}
-
-func Blake2b512FromPtr(dataPtr *[]byte) ([]byte, error) {
-	// Create a new BLAKE2b-512 hasher (no key)
-	h, err := blake2b.New512(nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Feed it the bytes
-	h.Write(*dataPtr)
-
-	// Return the digest
-	return h.Sum(nil), nil
 }
 
 func doLog(verbose bool, format string, args ...interface{}) {


### PR DESCRIPTION
## Summary
- drop leftover block size constant and block-related struct fields
- run `go vet`, `go test`, and `go build`

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6846084de0d8832aa53048708d6366f2