### PR TITLE
Fix tests by resetting features and version

### DIFF
--- a/archive_test.go
+++ b/archive_test.go
@@ -81,10 +81,9 @@ func TestArchiveScenarios(t *testing.T) {
 	for _, ver := range []uint16{version1, version2} {
 		for _, tc := range cases {
 			t.Run(fmt.Sprintf("v%v_%s", ver, tc.name), func(t *testing.T) {
+				features = 0
 				if ver == version2 {
 					features.Set(fBlock)
-				} else {
-					features.Clear(fBlock)
 				}
 				version = ver
 
@@ -101,7 +100,7 @@ func TestArchiveScenarios(t *testing.T) {
 				archivePath = filepath.Join(tempDir, "test.goxa")
 				toStdOut = false
 				doForce = false
-				features = tc.createFlags | features
+				features |= tc.createFlags
 
 				cwd, _ := os.Getwd()
 				os.Chdir(tempDir)
@@ -112,7 +111,11 @@ func TestArchiveScenarios(t *testing.T) {
 				}
 
 				os.RemoveAll(root)
-				features = tc.extractFlags | features
+				features = 0
+				if ver == version2 {
+					features.Set(fBlock)
+				}
+				features |= tc.extractFlags
 
 				var dest string
 				if tc.extractFlags.IsSet(fAbsolutePaths) {
@@ -166,6 +169,7 @@ func TestArchiveParentRelative(t *testing.T) {
 
 	archivePath = filepath.Join(tempDir, "test.goxa")
 	features = 0
+	version = version1
 	toStdOut = false
 	doForce = false
 
@@ -209,6 +213,7 @@ func TestSymlinkAndHardlink(t *testing.T) {
 
 	archivePath = filepath.Join(tempDir, "test.goxa")
 	features = fSpecialFiles
+	version = version1
 	toStdOut = false
 	doForce = false
 

--- a/extract_list_test.go
+++ b/extract_list_test.go
@@ -24,6 +24,7 @@ func TestExtractListOption(t *testing.T) {
 
 	archivePath = filepath.Join(tempDir, "test.goxa")
 	features = 0
+	version = version1
 	toStdOut = false
 	doForce = false
 

--- a/unicode_test.go
+++ b/unicode_test.go
@@ -23,6 +23,7 @@ func TestUnicodeFilenames(t *testing.T) {
 
 	archivePath = filepath.Join(tempDir, "test.goxa")
 	features = 0
+	version = version1
 	toStdOut = false
 	doForce = false
 


### PR DESCRIPTION
## Summary
- reset global `features` for each scenario
- set archive format version to v1 in tests that don't use block mode

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68477eb06fb0832ab75f1a2d1e635671