### PR TITLE
Fix directory mod time preservation in extract

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -310,6 +310,9 @@ func extract(destinations []string, listOnly bool) {
 			}
 			log.Fatalf("extract: unable to create directory %v: %v", dirPath, err)
 		}
+		if lfeat.IsSet(fModDates) {
+			os.Chtimes(dirPath, item.ModTime, item.ModTime)
+		}
 	}
 	arc.Close()
 


### PR DESCRIPTION
## Summary
- set modification times for directories when extracting

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68478068673c832a9f140488649350eb