### PR TITLE
Enforce extraction flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ goxa [mode] [flags] -arc=archiveFile [paths...]
 | `n` | Disable compression |
 | `i` | Include hidden files |
 | `o` | Include special files |
+| `u` | Use flags stored in archive |
 | `v` | Verbose logging |
 | `f` | Force overwrite / ignore errors |
 
-Paths default to relative. Using `a` when extracting restores absolute paths.
+Paths default to relative. Using `a` when extracting restores absolute paths. By default extraction does not restore permissions, modification times, hidden files, or special files unless `p`, `m`, `i`, or `o` are specified (or `u` to use the archive flags).
 
 ### Extra Flags
 
@@ -79,6 +80,7 @@ Progress shows transfer speed and the current file being processed.
 goxa c -arc=mybackup.goxa myStuff/
 goxa capmsif -arc=mybackup.goxa ~/
 goxa x -arc=mybackup.goxa
+goxa xu -arc=mybackup.goxa     # use archive flags
 goxa l -arc=mybackup.goxa
 ```
 

--- a/archive_test.go
+++ b/archive_test.go
@@ -70,12 +70,12 @@ func TestArchiveScenarios(t *testing.T) {
 	}{
 		{"rel_compress", 0, 0, false, false},
 		{"rel_nocompress", fNoCompress, 0, false, false},
-		{"rel_invis", fIncludeInvis, 0, true, false},
+		{"rel_invis", fIncludeInvis, fIncludeInvis, true, false},
 		{"abs_compress", fAbsolutePaths, fAbsolutePaths, false, false},
 		{"abs_nocompress", fAbsolutePaths | fNoCompress, fAbsolutePaths, false, false},
-		{"abs_invis", fAbsolutePaths | fIncludeInvis, fAbsolutePaths, true, false},
-		{"rel_all_flags", fPermissions | fChecksums | fIncludeInvis | fNoCompress, 0, true, true},
-		{"abs_all_flags", fAbsolutePaths | fPermissions | fChecksums | fIncludeInvis | fNoCompress, fAbsolutePaths, true, true},
+		{"abs_invis", fAbsolutePaths | fIncludeInvis, fAbsolutePaths | fIncludeInvis, true, false},
+		{"rel_all_flags", fPermissions | fChecksums | fIncludeInvis | fNoCompress, fPermissions | fIncludeInvis, true, true},
+		{"abs_all_flags", fAbsolutePaths | fPermissions | fChecksums | fIncludeInvis | fNoCompress, fAbsolutePaths | fPermissions | fIncludeInvis, true, true},
 	}
 
 	for _, tc := range cases {

--- a/bitFlag.go
+++ b/bitFlag.go
@@ -32,12 +32,38 @@ func showFeatures(flags BitFlags) {
 	for x := 0; 1<<x < fTop; x++ {
 		if flags.IsSet(1 << x) {
 			if flagStr != "" {
-				flagStr = flagStr + ", "
+				flagStr += ", "
 			}
-			flagStr = flagStr + flagNames[x]
+			flagStr += flagNames[x]
 		}
 	}
 	if flagStr != "" {
-		doLog(false, "Archive Flags: %v", flagStr)
+		doLog(false, "Archive Flags: %v (%s)", flagStr, flagLetters(flags))
 	}
+}
+
+func flagLetters(flags BitFlags) string {
+	out := ""
+	if flags.IsSet(fAbsolutePaths) {
+		out += "a"
+	}
+	if flags.IsSet(fPermissions) {
+		out += "p"
+	}
+	if flags.IsSet(fModDates) {
+		out += "m"
+	}
+	if flags.IsSet(fChecksums) {
+		out += "s"
+	}
+	if flags.IsSet(fNoCompress) {
+		out += "n"
+	}
+	if flags.IsSet(fIncludeInvis) {
+		out += "i"
+	}
+	if flags.IsSet(fSpecialFiles) {
+		out += "o"
+	}
+	return out
 }

--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ var (
 	archivePath                              string
 	verboseMode, doForce, toStdOut, progress bool
 	features                                 BitFlags
+	useArchiveFlags                          bool
 	compression                              string
 	extractList                              []string
 	version                                  uint16 = version2

--- a/extract.go
+++ b/extract.go
@@ -105,6 +105,29 @@ func extract(destinations []string, listOnly bool) {
 	}
 	showFeatures(lfeat)
 
+	if useArchiveFlags {
+		features |= lfeat
+	} else {
+		missing := ""
+		if lfeat.IsSet(fPermissions) && features.IsNotSet(fPermissions) {
+			missing += "p"
+		}
+		if lfeat.IsSet(fModDates) && features.IsNotSet(fModDates) {
+			missing += "m"
+		}
+		if lfeat.IsSet(fSpecialFiles) && features.IsNotSet(fSpecialFiles) {
+			missing += "o"
+		}
+		if lfeat.IsSet(fIncludeInvis) && features.IsNotSet(fIncludeInvis) {
+			missing += "i"
+		}
+		if missing != "" {
+			doLog(false, "Archive uses flags '%s'. Rerun with these flags or 'u' to auto-enable.", missing)
+			arc.Close()
+			return
+		}
+	}
+
 	var blkSize uint32 = blockSize
 	var trailerOffset uint64
 	if readVersion >= version2 {

--- a/main.go
+++ b/main.go
@@ -76,6 +76,8 @@ func main() {
 			features.Set(fIncludeInvis)
 		case 'o':
 			features.Set(fSpecialFiles)
+		case 'u':
+			useArchiveFlags = true
 		case 'v':
 			verboseMode = true
 		case 'f':
@@ -138,7 +140,7 @@ func main() {
 }
 
 func showUsage() {
-	fmt.Println("Usage: goxa [c|l|x][apmsniveo] -arc=arcFile [-comp=alg] [input paths/files...] or [destination]")
+	fmt.Println("Usage: goxa [c|l|x][apmsniveou] -arc=arcFile [-comp=alg] [input paths/files...] or [destination]")
 	fmt.Println("Output archive to stdout: -stdout, No progress bar: -progress=false")
 	fmt.Println("\nModes:")
 	fmt.Println("  c = Create a new archive. Requires input paths or files")
@@ -153,6 +155,7 @@ func showUsage() {
 	fmt.Print("  n = No-compression	")
 	fmt.Println("  i = Include dotfiles")
 	fmt.Print("  o = Special files          ")
+	fmt.Println("  u = Use archive flags")
 	fmt.Println("  v = Verbose logging")
 	fmt.Print("  f = Force (overwrite files and ignore read errors)")
 	fmt.Println("  -comp=gzip|zstd|lz4|s2|snappy|brotli|none")


### PR DESCRIPTION
## Summary
- add `useArchiveFlags` option
- warn and exit if archive flags require p/m/o/i and not provided
- add helper to display archive flag letters
- update docs for new `u` flag and changed defaults
- adjust tests for new default behavior

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684883b82a20832aab47a3ecd01d624c