### PR TITLE
Improve documentation clarity

### DIFF
--- a/FILE-FORMAT.md
+++ b/FILE-FORMAT.md
@@ -9,7 +9,7 @@ This document provides a compact description of the binary format used by the `g
 [Per-file data]
 ```
 
-The header lists metadata for empty directories and files along with an offset table. Actual file contents follow the header.
+The header contains metadata for empty directories and files along with an offset table. Actual file contents follow the header.
 
 ### Header
 - Magic bytes `GOXA`
@@ -36,6 +36,7 @@ The header lists metadata for empty directories and files along with an offset t
 | `fS2`           | 0x400 | Use s2 compression                        |
 | `fSnappy`       | 0x800 | Use snappy compression                    |
 | `fBrotli`       | 0x1000| Use brotli compression                    |
+| `fBlock`        | 0x2000| Enable block mode (v2 archives)           |
 
 Multiple flags may be combined.
 
@@ -82,17 +83,14 @@ For every file:
 
 ## Version 2 Additions
 
-Version 2 archives introduce block mode indicated by the `fBlock` flag. Two new
-fields are appended to the header:
+Version 2 archives introduce block mode indicated by the `fBlock` flag. The header includes two additional fields:
 
 ```
 [Block Size: uint32]
 [Trailer Offset: uint64]
 ```
 
-Files are compressed in fixed-size blocks (default 512&nbsp;KiB). After all file
-data comes a trailer containing a block index for each file followed by a 32‑byte
-checksum of the trailer.
+Files are compressed in fixed-size blocks (default 512&nbsp;KiB). After all file data comes a trailer containing a block index for each file followed by a 32‑byte checksum of the trailer.
 
 Trailer layout:
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 <img src="https://github.com/Distortions81/goXA/blob/main/Xango.png?raw=true" alt="Xango the Archivist" width="300"/>
 
 ## Xango the Pangolin Archivist
-GoXA is a gopher-friendly archiver written in Go. It's quick and simple, and still new enough that the paint is drying. Expect the odd bump and let the busy gophers know if you hit one.
+GoXA is a gopher-friendly archiver written in Go. It's quick and simple, but still young—please report any bumps you find.
 
 ## Features
 
 - [x] Fast archive creation and extraction
-- [x] Multiple compression formats (gzip, zstd, lz4, s2, snappy, brotli)
+- [x] Multiple compression formats (gzip, zstd, lz4, s2, snappy, brotli; defaults to gzip)
 - [x] Optional BLAKE2b-256 checksums
 - [x] Preserve permissions and modification times
 - [x] Fully documented binary format ([file-format.md](file-format.md))
 - [x] Optional support for symlinks and other special files
-- [x] Pure go code, no dependencies once compiled.
+- [x] Pure Go code with no runtime dependencies once compiled.
 
 ## File Format
 
@@ -59,7 +59,7 @@ goxa [mode] [flags] -arc=archiveFile [paths...]
 | `v` | Verbose logging |
 | `f` | Overwrite files / ignore read errors |
 
-Paths default to relative. Using `a` when extracting restores absolute paths if archived with them. By default extraction does not restore permissions, modification times, hidden files, or special files unless `p`, `m`, `i`, or `o` are specified (or `u` to use flags from archive).
+Paths are stored relative by default. Use `a` to store and restore absolute paths. Extraction only restores permissions, modification times, hidden files, or special files when `p`, `m`, `i`, or `o` are given (or `u` to use the archive's flags).
 
 ### Extra Flags
 
@@ -95,10 +95,10 @@ goxa l -arc=mybackup.goxa
 
 ## Security Notes
 
-- Paths are sanitized during extraction, but -a 'absolute paths' lets archives write wherever they like. Use with care on unknown files.
-- When using -o 'special files' symlinks are not resolved, so sneaky links can sidestep your destination folder.
-- The -u 'Use flags from in archive' uses whatever flags were used to create the archive. This can allow absolute paths, permissions, mod dates and special files. Use with care on unknown files.
-- Size fields use 'int64'; so maximum file size is 9223 petabytes.
+- Paths are sanitized during extraction, but `-a` (`absolute paths`) allows the archive to write anywhere. Use with care on unknown files.
+- With `-o` (`special files`) symlinks are not resolved, so sneaky links can sidestep your destination folder.
+- `-u` (`use flags from archive`) applies whatever options were set when the archive was created, which may enable absolute paths, permissions, mod dates and special files.
+- Size fields use `int64`; maximum individual file size is about 9,223 petabytes (~8&nbsp;EiB).
 
 ## License
 


### PR DESCRIPTION
## Summary
- reword the intro and feature list in README for clarity
- clarify flag behavior and security notes
- document default gzip compression
- describe block mode flag in FILE-FORMAT

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68488b85fa10832a901827b401e6ba06