### PR TITLE
Improve format and archive handling

### DIFF
--- a/FILE-FORMAT.md
+++ b/FILE-FORMAT.md
@@ -1,4 +1,4 @@
-# GoXA Archive Format (v1 & v2)
+# GoXA Archive Format (v2)
 
 This document provides a compact description of the binary format used by the `goxa` archiver. All integer fields are little-endian.
 
@@ -7,17 +7,19 @@ This document provides a compact description of the binary format used by the `g
 ```
 [Header]
 [Per-file data]
+[Trailer]
 ```
 
-The header lists metadata for empty directories and files along with an offset table. Actual file contents follow the header.
+The header contains metadata for empty directories and files. Actual file contents follow the header and end with a trailer containing the block index.
 
 ### Header
 - Magic bytes `GOXA`
 - Version (uint16)
 - Feature flags (uint32)
+- Block size (`uint32`)
+- Trailer offset (`uint64`)
 - Empty directory entries
 - File entries
-- Offset table (uint64 per file)
 
 ### Feature Flags
 
@@ -36,6 +38,7 @@ The header lists metadata for empty directories and files along with an offset t
 | `fS2`           | 0x400 | Use s2 compression                        |
 | `fSnappy`       | 0x800 | Use snappy compression                    |
 | `fBrotli`       | 0x1000| Use brotli compression                    |
+| `fBlock`        | 0x2000| Enable block mode (v2 archives)           |
 
 Multiple flags may be combined.
 
@@ -45,7 +48,9 @@ Multiple flags may be combined.
 [Empty Dir Count: uint64]
 [Empty Dir Entries...]
 ```
-Each entry optionally stores mode and mod time (controlled by flags) followed by path length and the UTF‑8 path.
+Each entry optionally stores mode and mod time (controlled by flags) followed by
+`[Path Length: uint16][UTF‑8 Path]`. Paths longer than 65,535 bytes cannot be
+stored.
 
 ### Files
 
@@ -54,15 +59,11 @@ Each entry optionally stores mode and mod time (controlled by flags) followed by
 [File Entries...]
 ```
 Each file entry contains:
-- Uncompressed size (uint64)
-- Optional mode and mod time
-- Path length and UTF‑8 path
-- Type byte (file, symlink, hardlink, etc.)
-- Link target for links
-
-### Offset Table
-
-Immediately after the file entries, an 8‑byte offset is stored for each file. These absolute offsets point into the data section.
+* Uncompressed size (`uint64`)
+* Optional mode (`uint32`) and mod time (`int64`)
+* `[Path Length: uint16][UTF‑8 Path]`
+* Type byte (`0`=file, `1`=symlink, `2`=hardlink, `3`=other)
+* `[Link Target Length: uint16][Target]` for links
 
 ### Per-file Data
 
@@ -76,35 +77,35 @@ For every file:
 [Magic][Version][Flags]
 [Empty Dir Count][Dirs]
 [File Count][Files]
-[Offset Table]
 [Checksums and Data]
+[Trailer]
 ```
 
-## Version 2 Additions
+## Trailer Format
 
-Version 2 archives introduce block mode indicated by the `fBlock` flag. Two new
-fields are appended to the header:
+Archives use block mode indicated by the `fBlock` flag. The header includes the block size and trailer offset fields:
 
 ```
 [Block Size: uint32]
 [Trailer Offset: uint64]
 ```
 
-Files are compressed in fixed-size blocks (default 512&nbsp;KiB). After all file
-data comes a trailer containing a block index for each file followed by a 32‑byte
-checksum of the trailer.
+Files are compressed in fixed-size blocks (default 512&nbsp;KiB). When
+`fNoCompress` is set the block size becomes `0` and each file is stored as a
+single block. After all file data comes a trailer containing a block index for
+each file followed by a 32‑byte BLAKE2b‑256 checksum of the trailer.
 
 Trailer layout:
 
 ```
 [Block Count: uint32]
-[Block Offsets and Sizes...]
-[Trailer Checksum]
+[ [Offset uint64][Size uint32] ... ]
+[Trailer Checksum: 32 bytes]
 ```
 
-A 32‑byte checksum of the header (including the trailer offset) is stored at the
-end of the header. Offsets in both the header and trailer are absolute within the
-archive.
+A 32‑byte BLAKE2b‑256 checksum of the header (including the trailer offset) is
+stored at the end of the header. Offsets in both the header and trailer are
+absolute within the archive.
 
 ### Notes
 - Directories that contain files are implied; only empty ones are listed.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 <img src="https://github.com/Distortions81/goXA/blob/main/Xango.png?raw=true" alt="Xango the Archivist" width="300"/>
 
 ## Xango the Pangolin Archivist
-GoXA is a gopher-friendly archiver written in Go. It's quick and simple, and still new enough that the paint is drying. Expect the odd bump and let the busy gophers know if you hit one.
+GoXA is a friendly archiver written in Go. It's fast and straightforward, though still maturing—please report any issues you find.
 
 ## Features
 
 - [x] Fast archive creation and extraction
-- [x] Multiple compression formats (gzip, zstd, lz4, s2, snappy, brotli)
+- [x] Multiple compression formats (gzip, zstd, lz4, s2, snappy, brotli; defaults to gzip)
 - [x] Optional BLAKE2b-256 checksums
 - [x] Preserve permissions and modification times
 - [x] Fully documented binary format ([file-format.md](file-format.md))
 - [x] Optional support for symlinks and other special files
-- [x] Pure go code, no dependencies once compiled.
+- [x] Block-based format for fast extraction (single block when uncompressed)
+- [x] Pure Go code with no runtime dependencies once compiled.
 
 ## File Format
 
@@ -59,7 +60,7 @@ goxa [mode] [flags] -arc=archiveFile [paths...]
 | `v` | Verbose logging |
 | `f` | Overwrite files / ignore read errors |
 
-Paths default to relative. Using `a` when extracting restores absolute paths if archived with them. By default extraction does not restore permissions, modification times, hidden files, or special files unless `p`, `m`, `i`, or `o` are specified (or `u` to use flags from archive).
+Paths are stored relative by default. Use `a` to store and restore absolute paths. Extraction only restores permissions, modification times, hidden files, or special files when `p`, `m`, `i`, or `o` are given (or `u` to use the archive's flags).
 
 ### Extra Flags
 
@@ -95,10 +96,10 @@ goxa l -arc=mybackup.goxa
 
 ## Security Notes
 
-- Paths are sanitized during extraction, but -a 'absolute paths' lets archives write wherever they like. Use with care on unknown files.
-- When using -o 'special files' symlinks are not resolved, so sneaky links can sidestep your destination folder.
-- The -u 'Use flags from in archive' uses whatever flags were used to create the archive. This can allow absolute paths, permissions, mod dates and special files. Use with care on unknown files.
-- Size fields use 'int64'; so maximum file size is 9223 petabytes.
+- Paths are sanitized during extraction, but `-a` (`absolute paths`) allows the archive to write anywhere. Use with care on unknown files.
+- With `-o` (`special files`) symlinks are not resolved, so sneaky links can sidestep your destination folder.
+- `-u` (`use flags from archive`) applies whatever options were set when the archive was created, which may enable absolute paths, permissions, mod dates and special files.
+- Size fields use `int64`; maximum individual file size is about 9,223 petabytes (~8&nbsp;EiB).
 
 ## License
 

--- a/extract.go
+++ b/extract.go
@@ -236,15 +236,6 @@ func extract(destinations []string, listOnly bool) {
 		return
 	}
 
-	//File offsets
-	for n := uint64(0); n < numFiles; n++ {
-		var fileOffset uint64
-		if err := binary.Read(arc, binary.LittleEndian, &fileOffset); err != nil {
-			log.Fatalf("extract: failed to read file offset: %v", err)
-		}
-		fileList[n].Offset = fileOffset
-	}
-
 	if readVersion >= version2 {
 		var hdrSum [checksumSize]byte
 		if _, err := io.ReadFull(arc, hdrSum[:]); err != nil {
@@ -274,6 +265,13 @@ func extract(destinations []string, listOnly bool) {
 				}
 			}
 			fileList[i].Blocks = blocks
+			if len(blocks) > 0 {
+				off := blocks[0].Offset
+				if lfeat.IsSet(fChecksums) {
+					off -= checksumSize
+				}
+				fileList[i].Offset = off
+			}
 		}
 		var tSum [checksumSize]byte
 		if _, err := io.ReadFull(arc, tSum[:]); err != nil {


### PR DESCRIPTION
## Summary
- archive creation always uses block-based v2 layout
- omit offset table and rely on trailer index
- when not compressing, block size becomes 0 and each file is a single block
- update README and FILE-FORMAT with new format details
- adjust tests for single-block archives

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68488b85fa10832a901827b401e6ba06