### PR TITLE
Add compression fields without changing version

### DIFF
--- a/block_system_test.go
+++ b/block_system_test.go
@@ -76,14 +76,26 @@ func parseArchive(t *testing.T, path string) []FileEntry {
 	if err := binary.Read(arc, binary.LittleEndian, &flags); err != nil {
 		t.Fatalf("read flags: %v", err)
 	}
+	var ctype uint8
 	var blkSize uint32 = blockSize
 	var trailerOff uint64
+	var arcSize uint64
+	if ver >= version2 {
+		if err := binary.Read(arc, binary.LittleEndian, &ctype); err != nil {
+			t.Fatalf("read compression type: %v", err)
+		}
+	}
 	if ver >= version2 {
 		if err := binary.Read(arc, binary.LittleEndian, &blkSize); err != nil {
 			t.Fatalf("read block size: %v", err)
 		}
 		if err := binary.Read(arc, binary.LittleEndian, &trailerOff); err != nil {
 			t.Fatalf("read trailer offset: %v", err)
+		}
+	}
+	if ver >= version2 {
+		if err := binary.Read(arc, binary.LittleEndian, &arcSize); err != nil {
+			t.Fatalf("read archive size: %v", err)
 		}
 	}
 

--- a/compression_test.go
+++ b/compression_test.go
@@ -9,16 +9,17 @@ import (
 
 func TestAllCompressions(t *testing.T) {
 	cases := []struct {
-		name string
-		flag BitFlags
+		name  string
+		ctype uint8
+		flag  BitFlags
 	}{
-		{"gzip", 0},
-		{"zstd", fZstd},
-		{"lz4", fLZ4},
-		{"s2", fS2},
-		{"snappy", fSnappy},
-		{"brotli", fBrotli},
-		{"none", fNoCompress},
+		{"gzip", compGzip, 0},
+		{"zstd", compZstd, 0},
+		{"lz4", compLZ4, 0},
+		{"s2", compS2, 0},
+		{"snappy", compSnappy, 0},
+		{"brotli", compBrotli, 0},
+		{"none", compGzip, fNoCompress},
 	}
 
 	for _, tc := range cases {
@@ -35,6 +36,7 @@ func TestAllCompressions(t *testing.T) {
 
 			archivePath = filepath.Join(tempDir, "test.goxa")
 			features = tc.flag
+			compType = tc.ctype
 			version = version2
 			toStdOut = false
 			doForce = false
@@ -50,6 +52,7 @@ func TestAllCompressions(t *testing.T) {
 			}
 
 			features = tc.flag
+			compType = tc.ctype
 			extract([]string{dest}, false)
 
 			extracted := filepath.Join(dest, filepath.Base(root), "file.txt")

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ var (
 	features                                 BitFlags
 	useArchiveFlags                          bool
 	compression                              string
+	compType                                 uint8 = compGzip
 	extractList                              []string
 	version                                  uint16 = version2
 	blockSize                                uint32 = defaultBlockSize

--- a/const.go
+++ b/const.go
@@ -42,3 +42,13 @@ const (
 	entryHardlink
 	entryOther
 )
+
+// Compression Types
+const (
+	compGzip uint8 = iota
+	compZstd
+	compLZ4
+	compS2
+	compSnappy
+	compBrotli
+)

--- a/extract_test.go
+++ b/extract_test.go
@@ -25,7 +25,7 @@ func TestExtractFileDirCreationFailure(t *testing.T) {
 
 	item := FileEntry{Path: filepath.Join("sub", "file.txt"), Offset: 1}
 
-	_ = extractFile(destFile+string(os.PathSeparator), 0, &item, &progressData{})
+	_ = extractFile(destFile+string(os.PathSeparator), 0, compGzip, &item, &progressData{})
 
 	if _, err := os.Stat(filepath.Join(tmp, "destfile", "sub")); err == nil {
 		t.Fatalf("directory should not be created")

--- a/main.go
+++ b/main.go
@@ -90,18 +90,20 @@ func main() {
 
 	switch strings.ToLower(compression) {
 	case "gzip":
+		compType = compGzip
 	case "zstd":
-		features.Set(fZstd)
+		compType = compZstd
 	case "lz4":
-		features.Set(fLZ4)
+		compType = compLZ4
 	case "s2":
-		features.Set(fS2)
+		compType = compS2
 	case "snappy":
-		features.Set(fSnappy)
+		compType = compSnappy
 	case "brotli":
-		features.Set(fBrotli)
+		compType = compBrotli
 	case "none":
 		features.Set(fNoCompress)
+		compType = compGzip
 	default:
 		log.Fatalf("Unknown compression: %s", compression)
 	}


### PR DESCRIPTION
## Summary
- keep archive format at v2 but include compression type and archive size
- update header writer/reader accordingly
- adjust tests and docs for the updated v2 format

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6848ba4c6268832a8d8db7fc2a54505b