### PR TITLE
Add tar archive support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GoXA is a friendly archiver written in Go. It's fast and straightforward, though
 
 - [x] Fast archive creation and extraction
 - [x] Multiple compression formats (gzip, zstd, lz4, s2, snappy, brotli; defaults to gzip)
-- [x] Standard tar archive support via `-format=tar`
+- [x] Standard tar archive support (auto-detected from `.tar` or `.tar.gz`)
 - [x] Optional BLAKE2b-256 checksums
 - [x] Preserve permissions and modification times
 - [x] Fully documented binary format ([FILE-FORMAT.md](FILE-FORMAT.md))
@@ -84,7 +84,8 @@ goxa capmsif -arc=mybackup.goxa ~/
 goxa x -arc=mybackup.goxa
 goxa xu -arc=mybackup.goxa     # use flags in archive (aka auto)
 goxa l -arc=mybackup.goxa
-goxa c -format=tar -arc=mybackup.tar myStuff/
+goxa c -arc=mybackup.tar.gz myStuff/
+goxa x -arc=mybackup.tar.gz
 ```
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GoXA is a friendly archiver written in Go. It's fast and straightforward, though
 
 - [x] Fast archive creation and extraction
 - [x] Multiple compression formats (gzip, zstd, lz4, s2, snappy, brotli; defaults to gzip)
-- [x] Standard tar archive support (auto-detected from `.tar`, `.tar.gz`, or `.tar.xz`)
+- [x] Standard tar archive support (auto-detected from extension or archive header)
 - [x] Optional BLAKE2b-256 checksums
 - [x] Preserve permissions and modification times
 - [x] Fully documented binary format ([FILE-FORMAT.md](FILE-FORMAT.md))

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ GoXA is a friendly archiver written in Go. It's fast and straightforward, though
 
 - [x] Fast archive creation and extraction
 - [x] Multiple compression formats (gzip, zstd, lz4, s2, snappy, brotli; defaults to gzip)
+- [x] Standard tar archive support via `-format=tar`
 - [x] Optional BLAKE2b-256 checksums
 - [x] Preserve permissions and modification times
 - [x] Fully documented binary format ([FILE-FORMAT.md](FILE-FORMAT.md))
@@ -71,6 +72,7 @@ Paths are stored relative by default. Use `a` to store and restore absolute path
 | `-files` | Comma-separated list of files and directories to extract |
 | `-progress=false` | Disable progress display |
 | `-comp=` | Compression algorithm (gzip, zstd, lz4, s2, snappy, brotli, none) |
+| `-format=` | Archive format (`goxa` or `tar`) |
 
 Progress shows transfer speed and the current file being processed.
 
@@ -82,6 +84,7 @@ goxa capmsif -arc=mybackup.goxa ~/
 goxa x -arc=mybackup.goxa
 goxa xu -arc=mybackup.goxa     # use flags in archive (aka auto)
 goxa l -arc=mybackup.goxa
+goxa c -format=tar -arc=mybackup.tar myStuff/
 ```
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GoXA is a friendly archiver written in Go. It's fast and straightforward, though
 
 - [x] Fast archive creation and extraction
 - [x] Multiple compression formats (gzip, zstd, lz4, s2, snappy, brotli; defaults to gzip)
-- [x] Standard tar archive support (auto-detected from `.tar` or `.tar.gz`)
+- [x] Standard tar archive support (auto-detected from `.tar`, `.tar.gz`, or `.tar.xz`)
 - [x] Optional BLAKE2b-256 checksums
 - [x] Preserve permissions and modification times
 - [x] Fully documented binary format ([FILE-FORMAT.md](FILE-FORMAT.md))
@@ -86,6 +86,8 @@ goxa xu -arc=mybackup.goxa     # use flags in archive (aka auto)
 goxa l -arc=mybackup.goxa
 goxa c -arc=mybackup.tar.gz myStuff/
 goxa x -arc=mybackup.tar.gz
+goxa c -arc=mybackup.tar.xz myStuff/
+goxa x -arc=mybackup.tar.xz
 ```
 
 ## Roadmap

--- a/cli_e2e_test.go
+++ b/cli_e2e_test.go
@@ -140,3 +140,48 @@ func TestCLITarXzAutoDetect(t *testing.T) {
 		t.Fatalf("content mismatch")
 	}
 }
+
+func TestCLITarHeaderDetect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CLI end-to-end test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := []byte("hello")
+	if err := os.WriteFile(filepath.Join(root, "file.txt"), data, 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	archive := filepath.Join(tempDir, "test.tar.gz")
+
+	resetGlobals()
+	os.Args = []string{"goxa", "c", "-arc=" + archive, "-progress=false", root}
+	main()
+
+	noExt := filepath.Join(tempDir, "archive")
+	if err := os.Rename(archive, noExt); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	dest := filepath.Join(tempDir, "out")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+
+	resetGlobals()
+	os.Args = []string{"goxa", "x", "-arc=" + noExt, "-progress=false", dest}
+	main()
+
+	extracted := filepath.Join(dest, filepath.Base(root), "file.txt")
+	out, err := os.ReadFile(extracted)
+	if err != nil {
+		t.Fatalf("read extracted: %v", err)
+	}
+	if !bytes.Equal(out, data) {
+		t.Fatalf("content mismatch")
+	}
+}

--- a/cli_e2e_test.go
+++ b/cli_e2e_test.go
@@ -59,3 +59,43 @@ func TestCLIEndToEnd(t *testing.T) {
 		t.Fatalf("content mismatch")
 	}
 }
+
+func TestCLITarAutoDetect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CLI end-to-end test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := []byte("hello")
+	if err := os.WriteFile(filepath.Join(root, "file.txt"), data, 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	archive := filepath.Join(tempDir, "test.tar.gz")
+
+	resetGlobals()
+	os.Args = []string{"goxa", "c", "-arc=" + archive, "-progress=false", root}
+	main()
+
+	dest := filepath.Join(tempDir, "out")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+
+	resetGlobals()
+	os.Args = []string{"goxa", "x", "-arc=" + archive, "-progress=false", dest}
+	main()
+
+	extracted := filepath.Join(dest, filepath.Base(root), "file.txt")
+	out, err := os.ReadFile(extracted)
+	if err != nil {
+		t.Fatalf("read extracted: %v", err)
+	}
+	if !bytes.Equal(out, data) {
+		t.Fatalf("content mismatch")
+	}
+}

--- a/cli_e2e_test.go
+++ b/cli_e2e_test.go
@@ -16,6 +16,7 @@ func resetGlobals() {
 	features = 0
 	compression = ""
 	extractList = nil
+	tarUseXz = false
 	version = version2
 	blockSize = defaultBlockSize
 }
@@ -76,6 +77,46 @@ func TestCLITarAutoDetect(t *testing.T) {
 	}
 
 	archive := filepath.Join(tempDir, "test.tar.gz")
+
+	resetGlobals()
+	os.Args = []string{"goxa", "c", "-arc=" + archive, "-progress=false", root}
+	main()
+
+	dest := filepath.Join(tempDir, "out")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+
+	resetGlobals()
+	os.Args = []string{"goxa", "x", "-arc=" + archive, "-progress=false", dest}
+	main()
+
+	extracted := filepath.Join(dest, filepath.Base(root), "file.txt")
+	out, err := os.ReadFile(extracted)
+	if err != nil {
+		t.Fatalf("read extracted: %v", err)
+	}
+	if !bytes.Equal(out, data) {
+		t.Fatalf("content mismatch")
+	}
+}
+
+func TestCLITarXzAutoDetect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CLI end-to-end test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := []byte("hello")
+	if err := os.WriteFile(filepath.Join(root, "file.txt"), data, 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	archive := filepath.Join(tempDir, "test.tar.xz")
 
 	resetGlobals()
 	os.Args = []string{"goxa", "c", "-arc=" + archive, "-progress=false", root}

--- a/config.go
+++ b/config.go
@@ -12,6 +12,7 @@ var (
 	useArchiveFlags                          bool
 	compression                              string
 	compType                                 uint8 = compGzip
+	tarUseXz                                 bool
 	extractList                              []string
 	version                                  uint16 = version2
 	blockSize                                uint32 = defaultBlockSize

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/klauspost/pgzip v1.2.6
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/remeh/sizedwaitgroup v1.0.0
+	github.com/ulikunitz/xz v0.5.12
 	golang.org/x/crypto v0.38.0
 	golang.org/x/term v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7Kyl5E=
 github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
+github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
+github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=

--- a/main.go
+++ b/main.go
@@ -62,6 +62,19 @@ func main() {
 		}
 	}
 
+	if cmdLetter != 'c' {
+		if fFmt, fNoComp, ok := detectFormatFromHeader(archivePath); ok {
+			format = fFmt
+			if fFmt == "tar" {
+				if fNoComp {
+					features.Set(fNoCompress)
+				} else {
+					features.Clear(fNoCompress)
+				}
+			}
+		}
+	}
+
 	if sel != "" {
 		parts := strings.Split(sel, ",")
 		for _, p := range parts {

--- a/main.go
+++ b/main.go
@@ -34,6 +34,11 @@ func main() {
 		return
 	}
 	cmd := strings.ToLower(os.Args[1])
+	cmdLetter := cmd[0]
+	opts := ""
+	if len(cmd) > 1 {
+		opts = cmd[1:]
+	}
 	flagSet := flag.NewFlagSet("goxa", flag.ExitOnError)
 	var sel string
 	var format string
@@ -56,7 +61,6 @@ func main() {
 			}
 		}
 	}
-	archivePath = stripArchiveExt(archivePath)
 
 	if sel != "" {
 		parts := strings.Split(sel, ",")
@@ -72,7 +76,7 @@ func main() {
 	// Clean up archive name will occur after options are parsed
 
 	//Options
-	for _, letter := range cmd {
+	for _, letter := range opts {
 		switch letter {
 
 		case 'a':
@@ -98,7 +102,6 @@ func main() {
 		default:
 			continue
 		}
-		cmd = cmd[:len(cmd)-1]
 	}
 
 	switch strings.ToLower(compression) {
@@ -121,24 +124,20 @@ func main() {
 		log.Fatalf("Unknown compression: %s", compression)
 	}
 
-	// finalize archive name with extension
-	if strings.ToLower(format) == "tar" {
-		if features.IsNotSet(fNoCompress) {
-			archivePath += ".tar.gz"
+	if cmdLetter == 'c' && !hasKnownArchiveExt(archivePath) {
+		if strings.ToLower(format) == "tar" {
+			if features.IsNotSet(fNoCompress) {
+				archivePath += ".tar.gz"
+			} else {
+				archivePath += ".tar"
+			}
 		} else {
-			archivePath += ".tar"
+			archivePath += ".goxa"
 		}
-	} else {
-		archivePath += ".goxa"
-	}
-
-	if len(cmd) == 0 {
-		showUsage()
-		log.Fatal("No mode specified")
 	}
 
 	//Modes
-	switch cmd[0] {
+	switch cmdLetter {
 	case 'c':
 		if strings.ToLower(format) == "tar" {
 			if err := createTar(flagSet.Args()); err != nil {

--- a/tar.go
+++ b/tar.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// createTar creates a tar archive from the provided paths.
+// When fNoCompress is not set, the archive is gzip compressed.
+func createTar(paths []string) error {
+	f, err := os.Create(archivePath)
+	if err != nil {
+		return err
+	}
+	var w io.WriteCloser = f
+	if features.IsNotSet(fNoCompress) {
+		gw := gzip.NewWriter(f)
+		w = gw
+		defer f.Close()
+		defer gw.Close()
+	} else {
+		defer f.Close()
+	}
+
+	tw := tar.NewWriter(w)
+	defer tw.Close()
+
+	for _, root := range paths {
+		root = filepath.Clean(root)
+		err := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			header, err := tar.FileInfoHeader(info, "")
+			if err != nil {
+				return err
+			}
+			header.Name = storedPath(root, p)
+			if info.Mode()&os.ModeSymlink != 0 {
+				if link, lerr := os.Readlink(p); lerr == nil {
+					header.Linkname = link
+				}
+			}
+			if info.IsDir() && header.Name != "." {
+				header.Name += "/"
+			}
+			if err := tw.WriteHeader(header); err != nil {
+				return err
+			}
+			if info.Mode().IsRegular() {
+				file, err := os.Open(p)
+				if err != nil {
+					return err
+				}
+				if _, err := io.Copy(tw, file); err != nil {
+					file.Close()
+					return err
+				}
+				file.Close()
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractTar extracts a tar archive into destination. When fNoCompress is not set,
+// the archive is assumed to be gzip compressed.
+func extractTar(destination string) error {
+	r, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	var src io.Reader = r
+	if features.IsNotSet(fNoCompress) {
+		gr, err := gzip.NewReader(r)
+		if err != nil {
+			r.Close()
+			return err
+		}
+		src = gr
+		defer gr.Close()
+	}
+	defer r.Close()
+
+	tr := tar.NewReader(src)
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		target, err := safeJoin(destination, hdr.Name)
+		if err != nil {
+			return err
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
+				return err
+			}
+			os.Chtimes(target, hdr.ModTime, hdr.ModTime)
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			if err := os.Symlink(hdr.Linkname, target); err != nil {
+				return err
+			}
+		case tar.TypeLink:
+			if err := os.Link(hdr.Linkname, target); err != nil {
+				return err
+			}
+		default:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			w, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode))
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(w, tr); err != nil {
+				w.Close()
+				return err
+			}
+			w.Close()
+			os.Chtimes(target, hdr.ModTime, hdr.ModTime)
+		}
+	}
+	return nil
+}

--- a/tar_test.go
+++ b/tar_test.go
@@ -64,14 +64,14 @@ func TestTarBasic(t *testing.T) {
 			specs := setupTarTree(t, root)
 
 			archivePath = filepath.Join(tempDir, "test.tar")
-			features = 0
+			features = fIncludeInvis
 			tarUseXz = false
 			if tc.name == "xz" {
 				tarUseXz = true
 				archivePath += ".xz"
 			}
 			if tc.noComp {
-				features = fNoCompress
+				features |= fNoCompress
 			}
 			if err := createTar([]string{root}); err != nil {
 				t.Fatalf("createTar failed: %v", err)
@@ -103,7 +103,7 @@ func TestTarModTime(t *testing.T) {
 	os.Chtimes(filePath, modTime, modTime)
 
 	archivePath = filepath.Join(tempDir, "test.tar")
-	features = 0
+	features = fModDates
 	if err := createTar([]string{root}); err != nil {
 		t.Fatalf("createTar: %v", err)
 	}

--- a/tar_test.go
+++ b/tar_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type tarFileSpec struct {
+	rel  string
+	data []byte
+	perm fs.FileMode
+}
+
+func setupTarTree(t *testing.T, root string) []tarFileSpec {
+	old := syscall.Umask(0)
+	defer syscall.Umask(old)
+	files := []tarFileSpec{
+		{rel: "dir1/file1.txt", data: []byte("file1"), perm: 0o754},
+		{rel: "dir1/.hidden", data: []byte("hidden1"), perm: 0o600},
+		{rel: "dir2/file2.txt", data: []byte("file2"), perm: 0o640},
+		{rel: ".hiddendir/hfile.txt", data: []byte("hidden2"), perm: 0o600},
+		{rel: "rootfile.txt", data: []byte("root"), perm: 0o664},
+	}
+	for _, f := range files {
+		full := filepath.Join(root, f.rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, f.data, f.perm); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	return files
+}
+
+func tarCheckFile(t *testing.T, path string, expect []byte) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %v: %v", path, err)
+	}
+	if !bytes.Equal(data, expect) {
+		t.Fatalf("content mismatch for %v", path)
+	}
+}
+
+func TestTarBasic(t *testing.T) {
+	cases := []struct {
+		name   string
+		noComp bool
+	}{
+		{"compress", false},
+		{"nocompress", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			root := filepath.Join(tempDir, "root")
+			specs := setupTarTree(t, root)
+
+			archivePath = filepath.Join(tempDir, "test.tar")
+			features = 0
+			if tc.noComp {
+				features = fNoCompress
+			}
+			if err := createTar([]string{root}); err != nil {
+				t.Fatalf("createTar failed: %v", err)
+			}
+
+			os.RemoveAll(root)
+			dest := filepath.Join(tempDir, "out")
+			os.MkdirAll(dest, 0o755)
+			if err := extractTar(dest); err != nil {
+				t.Fatalf("extractTar failed: %v", err)
+			}
+
+			base := filepath.Join(dest, filepath.Base(root))
+			for _, sp := range specs {
+				tarCheckFile(t, filepath.Join(base, sp.rel), sp.data)
+			}
+		})
+	}
+}
+
+func TestTarModTime(t *testing.T) {
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "root")
+	filePath := filepath.Join(root, "file.txt")
+	os.MkdirAll(root, 0o755)
+	content := []byte("hi")
+	os.WriteFile(filePath, content, 0o644)
+	modTime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	os.Chtimes(filePath, modTime, modTime)
+
+	archivePath = filepath.Join(tempDir, "test.tar")
+	features = 0
+	if err := createTar([]string{root}); err != nil {
+		t.Fatalf("createTar: %v", err)
+	}
+	os.RemoveAll(root)
+	dest := filepath.Join(tempDir, "out")
+	os.MkdirAll(dest, 0o755)
+	if err := extractTar(dest); err != nil {
+		t.Fatalf("extractTar: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dest, filepath.Base(root), "file.txt"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.ModTime().UTC().Truncate(time.Second) != modTime {
+		t.Fatalf("mod time mismatch")
+	}
+}

--- a/tar_test.go
+++ b/tar_test.go
@@ -55,6 +55,7 @@ func TestTarBasic(t *testing.T) {
 	}{
 		{"compress", false},
 		{"nocompress", true},
+		{"xz", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -64,6 +65,11 @@ func TestTarBasic(t *testing.T) {
 
 			archivePath = filepath.Join(tempDir, "test.tar")
 			features = 0
+			tarUseXz = false
+			if tc.name == "xz" {
+				tarUseXz = true
+				archivePath += ".xz"
+			}
 			if tc.noComp {
 				features = fNoCompress
 			}

--- a/util.go
+++ b/util.go
@@ -28,6 +28,37 @@ func removeExtension(filename string) string {
 	return filename[:len(filename)-len(extension)]
 }
 
+// detectFormatFromExt inspects the archive filename to infer the format.
+// It returns "tar" or "goxa" and whether the tar archive is uncompressed.
+func detectFormatFromExt(name string) (string, bool) {
+	lower := strings.ToLower(name)
+	if strings.HasSuffix(lower, ".tar.gz") {
+		return "tar", false
+	}
+	if strings.HasSuffix(lower, ".tar") {
+		return "tar", true
+	}
+	if strings.HasSuffix(lower, ".goxa") {
+		return "goxa", false
+	}
+	return "", false
+}
+
+// stripArchiveExt removes a known archive extension from name.
+func stripArchiveExt(name string) string {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.HasSuffix(lower, ".tar.gz"):
+		return name[:len(name)-len(".tar.gz")]
+	case strings.HasSuffix(lower, ".tar"):
+		return name[:len(name)-len(".tar")]
+	case strings.HasSuffix(lower, ".goxa"):
+		return name[:len(name)-len(".goxa")]
+	default:
+		return removeExtension(name)
+	}
+}
+
 func doLog(verbose bool, format string, args ...interface{}) {
 	if toStdOut || (!verboseMode && verbose) {
 		return

--- a/util.go
+++ b/util.go
@@ -55,8 +55,13 @@ func stripArchiveExt(name string) string {
 	case strings.HasSuffix(lower, ".goxa"):
 		return name[:len(name)-len(".goxa")]
 	default:
-		return removeExtension(name)
+		return name
 	}
+}
+
+func hasKnownArchiveExt(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tar") || strings.HasSuffix(lower, ".goxa")
 }
 
 func doLog(verbose bool, format string, args ...interface{}) {

--- a/util.go
+++ b/util.go
@@ -32,7 +32,12 @@ func removeExtension(filename string) string {
 // It returns "tar" or "goxa" and whether the tar archive is uncompressed.
 func detectFormatFromExt(name string) (string, bool) {
 	lower := strings.ToLower(name)
+	tarUseXz = false
 	if strings.HasSuffix(lower, ".tar.gz") {
+		return "tar", false
+	}
+	if strings.HasSuffix(lower, ".tar.xz") {
+		tarUseXz = true
 		return "tar", false
 	}
 	if strings.HasSuffix(lower, ".tar") {
@@ -50,6 +55,8 @@ func stripArchiveExt(name string) string {
 	switch {
 	case strings.HasSuffix(lower, ".tar.gz"):
 		return name[:len(name)-len(".tar.gz")]
+	case strings.HasSuffix(lower, ".tar.xz"):
+		return name[:len(name)-len(".tar.xz")]
 	case strings.HasSuffix(lower, ".tar"):
 		return name[:len(name)-len(".tar")]
 	case strings.HasSuffix(lower, ".goxa"):
@@ -61,7 +68,7 @@ func stripArchiveExt(name string) string {
 
 func hasKnownArchiveExt(name string) bool {
 	lower := strings.ToLower(name)
-	return strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tar") || strings.HasSuffix(lower, ".goxa")
+	return strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tar.xz") || strings.HasSuffix(lower, ".tar") || strings.HasSuffix(lower, ".goxa")
 }
 
 func doLog(verbose bool, format string, args ...interface{}) {

--- a/util.go
+++ b/util.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -10,6 +12,10 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"compress/gzip"
+
+	"github.com/ulikunitz/xz"
 )
 
 func fileExists(filePath string) (bool, error) {
@@ -69,6 +75,71 @@ func stripArchiveExt(name string) string {
 func hasKnownArchiveExt(name string) bool {
 	lower := strings.ToLower(name)
 	return strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tar.xz") || strings.HasSuffix(lower, ".tar") || strings.HasSuffix(lower, ".goxa")
+}
+
+// detectTarHeader reports whether buf appears to be a tar archive by checking
+// for the ustar magic at the expected offset.
+func detectTarHeader(buf []byte) bool {
+	if len(buf) < 262 {
+		return false
+	}
+	return string(buf[257:262]) == "ustar"
+}
+
+// detectFormatFromHeader attempts to identify the archive format based on the
+// file's magic bytes. The returned bool indicates success.
+func detectFormatFromHeader(name string) (string, bool, bool) {
+	f, err := os.Open(name)
+	if err != nil {
+		return "", false, false
+	}
+	defer f.Close()
+
+	hdr := make([]byte, 6)
+	n, _ := io.ReadFull(f, hdr)
+	hdr = hdr[:n]
+
+	if n >= 4 && string(hdr[:4]) == magic {
+		return "goxa", false, true
+	}
+
+	if n >= 2 && hdr[0] == 0x1f && hdr[1] == 0x8b { // gzip
+		if _, err := f.Seek(0, io.SeekStart); err == nil {
+			gr, err := gzip.NewReader(f)
+			if err == nil {
+				buf := make([]byte, 512)
+				m, _ := io.ReadFull(gr, buf)
+				gr.Close()
+				if detectTarHeader(buf[:m]) {
+					return "tar", false, true
+				}
+			}
+		}
+	}
+
+	if n >= 6 && bytes.Equal(hdr, []byte{0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00}) { // xz
+		if _, err := f.Seek(0, io.SeekStart); err == nil {
+			xr, err := xz.NewReader(f)
+			if err == nil {
+				buf := make([]byte, 512)
+				m, _ := io.ReadFull(xr, buf)
+				if detectTarHeader(buf[:m]) {
+					tarUseXz = true
+					return "tar", false, true
+				}
+			}
+		}
+	}
+
+	if _, err := f.Seek(0, io.SeekStart); err == nil {
+		buf := make([]byte, 512)
+		m, _ := io.ReadFull(f, buf)
+		if detectTarHeader(buf[:m]) {
+			return "tar", true, true
+		}
+	}
+
+	return "", false, false
 }
 
 func doLog(verbose bool, format string, args ...interface{}) {


### PR DESCRIPTION
## Summary
- implement `createTar` and `extractTar` using `archive/tar`
- add `-format` flag to select between goxa and tar formats
- write `tar_test.go` with basic tar archive scenarios
- document tar usage in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6848c536cea0832ab66f4dac80530e73