### PR TITLE
Update docs for Blake3 default

### DIFF
--- a/FILE-FORMAT.md
+++ b/FILE-FORMAT.md
@@ -46,7 +46,7 @@ The header contains metadata for empty directories and files. Actual file conten
 | 3 | SHA‑256 |
 | 4 | Blake3 |
 
-CRC16 is used by default when checksums are enabled.
+Blake3 is used by default when checksums are enabled.
 
 ### Feature Flags
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GoXA is a friendly archiver written in Go. It's fast and straightforward, though
 - [x] Fast archive creation and extraction
 - [x] Multiple compression formats (gzip, zstd, lz4, s2, snappy, brotli, xz; defaults to zstd)
 - [x] Standard tar archive support (auto-detected from extension or archive header)
-- [x] Optional checksums (per-file or per-block; crc16, crc32, xxhash, sha-256, or blake3; default crc16)
+- [x] Optional checksums (per-file or per-block; crc16, crc32, xxhash, sha-256, or blake3; default blake3)
 - [x] Preserve permissions and modification times
 - [x] Fully documented binary format ([FILE-FORMAT.md](FILE-FORMAT.md))
 - [x] Optional support for symlinks and other special files


### PR DESCRIPTION
## Summary
- mention blake3 as the default checksum algorithm in README
- fix FILE-FORMAT docs to match

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684909b5aea8832a8509fa76ac1091bc