### PR TITLE
Remove unused compression flags

### DIFF
--- a/const.go
+++ b/const.go
@@ -30,18 +30,13 @@ const (
 	fNoCompress
 	fIncludeInvis
 	fSpecialFiles
-	fZstd
-	fLZ4
-	fS2
-	fSnappy
-	fBrotli
 	fBlockChecksums
 
 	fTop //Do not use, move or delete
 )
 
 var (
-	flagNames = []string{"None", "Absolute Paths", "Permissions", "Mod Dates", "Checksums", "No Compress", "Include Invis", "Special Files", "Zstd", "LZ4", "S2", "Snappy", "Brotli", "Block Checksums", "Unknown"}
+	flagNames = []string{"None", "Absolute Paths", "Permissions", "Mod Dates", "Checksums", "No Compress", "Include Invis", "Special Files", "Block Checksums", "Unknown"}
 )
 
 // Entry Types


### PR DESCRIPTION
## Summary
- drop unused fZstd through fBrotli constants
- shrink `flagNames` accordingly

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684909ce9b20832ab580cd7aa62f00f8