### PR TITLE
Add -version CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Paths are stored relative by default. Use `a` to store and restore absolute path
 | `-comp=` | Compression algorithm (gzip, zstd, lz4, s2, snappy, brotli, xz, none) |
 | `-speed=` | Compression speed (fastest, default, better, best) |
 | `-format=` | Archive format (`goxa` or `tar`) |
+| `-version` | Print version and exit |
 
 Progress shows transfer speed and the current file being processed.
 
@@ -89,6 +90,7 @@ Snappy does not support configurable compression levels; `-speed` has no effect 
 ### Examples
 
 ```bash
+goxa -version
 goxa c -arc=mybackup.goxa myStuff/
 goxa capmsif -arc=mybackup.goxa ~/
 goxa x -arc=mybackup.goxa

--- a/main.go
+++ b/main.go
@@ -50,7 +50,13 @@ func main() {
 	flagSet.StringVar(&speedOpt, "speed", "fastest", "compression speed: fastest|default|better|best")
 	flagSet.StringVar(&format, "format", "goxa", "archive format: tar|goxa")
 	flagSet.StringVar(&sel, "files", "", "comma-separated list of files and directories to extract")
+	var showVer bool
+	flagSet.BoolVar(&showVer, "version", false, "print version and exit")
 	flagSet.Parse(os.Args[2:])
+	if showVer {
+		fmt.Println(version)
+		return
+	}
 
 	detFmt, noComp := detectFormatFromExt(archivePath)
 	if detFmt != "" {
@@ -242,6 +248,7 @@ func showUsage() {
 	fmt.Println("  -comp=gzip|zstd|lz4|s2|snappy|brotli|xz|none")
 	fmt.Println("  -speed=fastest|default|better|best")
 	fmt.Println("  -format=tar|goxa")
+	fmt.Println("  -version")
 	fmt.Println()
 	fmt.Println("  goxa c -arc=arcFile myStuff		(similar to zip)")
 	fmt.Println("  goxa cpmi -arc=arcFile myStuff	(similar to tar -czf)")


### PR DESCRIPTION
## Summary
- add -version flag to main.go
- show flag in usage text
- document version flag in README with example usage

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68490f77cf74832ab4a1d85148a2496c