### PR TITLE
Add JSON listing mode

### DIFF
--- a/JSON-LIST-FORMAT.md
+++ b/JSON-LIST-FORMAT.md
@@ -1,0 +1,29 @@
+# Extended List JSON Format
+
+The `j` mode of `goxa` prints a JSON document describing the archive
+without extracting it. The structure mirrors the information stored in
+the header and trailer while omitting internal offsets and block data.
+
+```json
+{
+  "version": 2,
+  "flags": 16,
+  "compression": "zstd",
+  "checksum": "blake3",
+  "checksumLength": 32,
+  "blockSize": 524288,
+  "archiveSize": 12345,
+  "dirs": [
+    { "path": "emptyDir", "mode": 493, "modTime": "2023-01-02T15:04:05Z" }
+  ],
+  "files": [
+    { "path": "file.txt", "type": "file", "size": 12,
+      "mode": 420, "modTime": "2023-01-02T15:04:05Z" }
+  ]
+}
+```
+
+`flags` corresponds to the feature bits listed in
+[FILE-FORMAT.md](FILE-FORMAT.md). `compression` and `checksum`
+match the tables in the same document. Entries for symlinks and
+hardlinks include a `link` field containing the target path.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ GoXA is a friendly archiver written in Go. It's fast and straightforward, though
 ## File Format
 
 See [FILE-FORMAT.md](FILE-FORMAT.md) for the full binary format.
+The JSON structure emitted by `j` mode is described in
+[JSON-LIST-FORMAT.md](JSON-LIST-FORMAT.md).
 
 ## Install
 
@@ -51,7 +53,7 @@ This creates the `goxa` binary.
 goxa [mode] [flags] -arc=archiveFile [paths...]
 ```
 
-`mode`: `c` (create), `l` (list), `x` (extract)
+`mode`: `c` (create), `l` (list), `j` (json list), `x` (extract)
 
 `flags`: any combination of:
 
@@ -96,6 +98,7 @@ goxa capmsif -arc=mybackup.goxa ~/
 goxa x -arc=mybackup.goxa
 goxa xu -arc=mybackup.goxa     # use flags in archive (aka auto)
 goxa l -arc=mybackup.goxa
+goxa j -arc=mybackup.goxa > listing.json
 goxa c -arc=mybackup.tar.gz myStuff/
 goxa x -arc=mybackup.tar.gz
 goxa c -arc=mybackup.tar.xz myStuff/

--- a/archive_test.go
+++ b/archive_test.go
@@ -112,13 +112,13 @@ func TestArchiveScenarios(t *testing.T) {
 
 			var dest string
 			if tc.extractFlags.IsSet(fAbsolutePaths) {
-				extract([]string{}, false)
+				extract([]string{}, false, false)
 			} else {
 				dest = filepath.Join(tempDir, "out")
 				if err := os.MkdirAll(dest, 0o755); err != nil {
 					t.Fatalf("mkdir dest: %v", err)
 				}
-				extract([]string{dest}, false)
+				extract([]string{dest}, false, false)
 			}
 
 			var base string
@@ -179,7 +179,7 @@ func TestArchiveParentRelative(t *testing.T) {
 	if err := os.MkdirAll(dest, 0o755); err != nil {
 		t.Fatalf("mkdir dest: %v", err)
 	}
-	extract([]string{dest}, false)
+	extract([]string{dest}, false, false)
 
 	extracted := filepath.Join(dest, filepath.Base(root), "file.txt")
 	checkFile(t, extracted, data, 0o644, false)
@@ -217,7 +217,7 @@ func TestSymlinkAndHardlink(t *testing.T) {
 	dest := filepath.Join(tempDir, "out")
 	os.MkdirAll(dest, 0o755)
 	features = fSpecialFiles
-	extract([]string{dest}, false)
+	extract([]string{dest}, false, false)
 
 	base := filepath.Join(dest, filepath.Base(root))
 	ltarget, err := os.Readlink(filepath.Join(base, "link.txt"))
@@ -258,7 +258,7 @@ func TestModDatePreservation(t *testing.T) {
 	dest := filepath.Join(tempDir, "out")
 	os.MkdirAll(dest, 0o755)
 	features = fModDates
-	extract([]string{dest}, false)
+	extract([]string{dest}, false, false)
 
 	base := filepath.Join(dest, filepath.Base(root))
 	info, err := os.Stat(filepath.Join(base, "file.txt"))
@@ -306,7 +306,7 @@ func TestBaseEncoding(t *testing.T) {
 		dest := filepath.Join(tempDir, "out")
 		os.MkdirAll(dest, 0o755)
 		encode = tc.enc
-		extract([]string{dest}, false)
+		extract([]string{dest}, false, false)
 
 		encode = ""
 

--- a/block_system_test.go
+++ b/block_system_test.go
@@ -227,7 +227,7 @@ func TestBlockArchiveLargeFiles(t *testing.T) {
 	os.RemoveAll(root)
 	dest := filepath.Join(tempDir, "out")
 	os.MkdirAll(dest, 0o755)
-	extract([]string{dest}, false)
+	extract([]string{dest}, false, false)
 
 	base := filepath.Join(dest, filepath.Base(root))
 	for _, sp := range specs {

--- a/compression_test.go
+++ b/compression_test.go
@@ -53,7 +53,7 @@ func TestAllCompressions(t *testing.T) {
 
 			features = tc.flag
 			compType = tc.ctype
-			extract([]string{dest}, false)
+			extract([]string{dest}, false, false)
 
 			extracted := filepath.Join(dest, filepath.Base(root), "file.txt")
 			out, err := os.ReadFile(extracted)

--- a/config.go
+++ b/config.go
@@ -38,3 +38,24 @@ type Block struct {
 	Offset uint64
 	Size   uint32
 }
+
+type ListEntry struct {
+	Path     string      `json:"path"`
+	Type     string      `json:"type"`
+	Size     uint64      `json:"size,omitempty"`
+	Mode     fs.FileMode `json:"mode,omitempty"`
+	ModTime  time.Time   `json:"modTime,omitempty"`
+	Linkname string      `json:"link,omitempty"`
+}
+
+type ArchiveListing struct {
+	Version        uint16      `json:"version"`
+	Flags          BitFlags    `json:"flags"`
+	Compression    string      `json:"compression"`
+	Checksum       string      `json:"checksum"`
+	ChecksumLength uint8       `json:"checksumLength"`
+	BlockSize      uint32      `json:"blockSize"`
+	ArchiveSize    uint64      `json:"archiveSize"`
+	Dirs           []ListEntry `json:"dirs"`
+	Files          []ListEntry `json:"files"`
+}

--- a/extract_list_test.go
+++ b/extract_list_test.go
@@ -42,7 +42,7 @@ func TestExtractListOption(t *testing.T) {
 	extractList = []string{filepath.Join(base, "sub1")}
 	defer func() { extractList = nil }()
 
-	extract([]string{dest}, false)
+	extract([]string{dest}, false, false)
 
 	checkFile(t, filepath.Join(dest, base, "sub1", "one.txt"), []byte("one"), 0o644, false)
 	if _, err := os.Stat(filepath.Join(dest, base, "sub2", "two.txt")); !os.IsNotExist(err) {

--- a/json_list_test.go
+++ b/json_list_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCLIJSONList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CLI end-to-end test in short mode")
+	}
+
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := []byte("hello")
+	if err := os.WriteFile(filepath.Join(root, "file.txt"), data, 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	archive := filepath.Join(tempDir, "test.goxa")
+
+	resetGlobals()
+	os.Args = []string{"goxa", "c", "-arc=" + archive, "-progress=false", root}
+	main()
+
+	resetGlobals()
+	os.Args = []string{"goxa", "j", "-arc=" + archive, "-progress=false", "-stdout"}
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	std := os.Stdout
+	os.Stdout = w
+	main()
+	w.Close()
+	os.Stdout = std
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+
+	var listing ArchiveListing
+	if err := json.Unmarshal(buf.Bytes(), &listing); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+	if len(listing.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(listing.Files))
+	}
+	exp := filepath.Join(filepath.Base(root), "file.txt")
+	if listing.Files[0].Path != exp {
+		t.Fatalf("unexpected path: %s", listing.Files[0].Path)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -191,7 +191,12 @@ func main() {
 		if strings.ToLower(format) == "tar" {
 			log.Fatalf("list not supported for tar format")
 		}
-		extract(flagSet.Args(), true)
+		extract(flagSet.Args(), true, false)
+	case 'j':
+		if strings.ToLower(format) == "tar" {
+			log.Fatalf("list not supported for tar format")
+		}
+		extract(flagSet.Args(), true, true)
 	case 'x':
 		if archivePath == defaultArchiveName {
 			log.Fatal("You must specify an archive to extract.")
@@ -211,7 +216,7 @@ func main() {
 			}
 			return
 		}
-		extract(flagSet.Args(), false)
+		extract(flagSet.Args(), false, false)
 	default:
 		showUsage()
 		doLog(false, "Unknown mode: %c", cmd[0])
@@ -220,11 +225,12 @@ func main() {
 }
 
 func showUsage() {
-	fmt.Println("Usage: goxa [c|l|x][apmsnbiveou] -arc=arcFile [-comp=alg] [input paths/files...] or [destination]")
+	fmt.Println("Usage: goxa [c|l|j|x][apmsnbiveou] -arc=arcFile [-comp=alg] [input paths/files...] or [destination]")
 	fmt.Println("Output archive to stdout: -stdout, No progress bar: -progress=false")
 	fmt.Println("\nModes:")
 	fmt.Println("  c = Create a new archive. Requires input paths or files")
 	fmt.Println("  l = List archive contents. Requires -arc")
+	fmt.Println("  j = JSON list of archive contents. Requires -arc")
 	fmt.Println("  x = Extract files from archive. Requires -arc")
 
 	fmt.Println("\nOptions:")

--- a/unicode_test.go
+++ b/unicode_test.go
@@ -40,7 +40,7 @@ func TestUnicodeFilenames(t *testing.T) {
 		t.Fatalf("failed to create dest: %v", err)
 	}
 
-	extract([]string{dest}, false)
+	extract([]string{dest}, false, false)
 
 	extracted := filepath.Join(dest, filepath.Base(root), fileName)
 	data, err := os.ReadFile(extracted)


### PR DESCRIPTION
## Summary
- implement extended JSON listing mode (`j`)
- document JSON list format
- provide example usage
- update CLI usage and tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684915ba7474832aab3f5dc3c23e2b49