### PR TITLE
Add man page and installer script

### DIFF
--- a/goxa.1
+++ b/goxa.1
@@ -1,0 +1,95 @@
+.TH GOXA 1 "" "" "User Commands"
+.SH NAME
+goxa \- fast archiving tool written in Go
+.SH SYNOPSIS
+.B goxa
+.RI "[mode] [flags]" " -arc=FILE [paths...]"
+.br
+.B goxa c
+.RI "[flags] -arc=FILE [paths...]"
+.br
+.B goxa l
+.RI "[flags] -arc=FILE"
+.br
+.B goxa x
+.RI "[flags] -arc=FILE [destination]"
+.SH DESCRIPTION
+GoXA is a friendly archiver written in Go. It can create, list and extract \fB.goxa\fP archives or standard tar files. The format supports compression, checksums and preservation of metadata.
+.SH MODES
+.TP
+.B c
+Create a new archive.
+.TP
+.B l
+List archive contents.
+.TP
+.B x
+Extract files from an archive.
+.SH FLAGS
+Single letter flags may be combined after the mode character:
+.TP
+.B a
+Store and restore absolute paths.
+.TP
+.B p
+Include file permissions.
+.TP
+.B m
+Include modification times.
+.TP
+.B s
+Enable checksums.
+.TP
+.B b
+Per-block checksums.
+.TP
+.B n
+Disable compression.
+.TP
+.B i
+Include hidden files.
+.TP
+.B o
+Allow special files.
+.TP
+.B u
+Use flags embedded in archive.
+.TP
+.B v
+Verbose logging.
+.TP
+.B f
+Force overwrite and ignore read errors.
+.PP
+Additional options:
+.TP
+.BI -arc= FILE
+Archive file name.
+.TP
+.B -stdout
+Write archive data to standard output.
+.TP
+.BI -files= LIST
+Comma separated list of files/directories to extract.
+.TP
+.B -progress=false
+Disable progress display.
+.TP
+.BI -comp= ALG
+Compression algorithm (gzip, zstd, lz4, s2, snappy, brotli, xz, none).
+.TP
+.BI -speed= LEVEL
+Compression speed (fastest, default, better, best).
+.TP
+.BI -format= TYPE
+Archive format (goxa or tar).
+.SH EXAMPLES
+.nf
+goxa c -arc=backup.goxa mydir/
+goxa capmsf -arc=backup.goxa ~/docs
+goxa x -arc=backup.goxa
+.fi
+.SH SEE ALSO
+tar(1), gzip(1)
+.SH AUTHOR
+https://github.com/Distortions81

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PREFIX=${PREFIX:-/usr/local}
+BINDIR="$PREFIX/bin"
+MANDIR="$PREFIX/share/man/man1"
+
+echo "Building goxa..."
+go build -o goxa .
+
+echo "Installing binary to $BINDIR"
+install -d "$BINDIR"
+install -m 755 goxa "$BINDIR/goxa"
+
+echo "Installing man page to $MANDIR"
+install -d "$MANDIR"
+if command -v gzip >/dev/null; then
+    gzip -c goxa.1 > "$MANDIR/goxa.1.gz"
+else
+    install -m 644 goxa.1 "$MANDIR/goxa.1"
+fi
+
+echo "Installation complete."


### PR DESCRIPTION
## Summary
- document goxa in a new `goxa(1)` man page
- add `install.sh` to build the binary and place it and the man page under a user-defined prefix

## Testing
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_68491645b1b8832ab756ed82b6d89295