### PR TITLE
Improve JSON listing output

### DIFF
--- a/JSON-LIST-FORMAT.md
+++ b/JSON-LIST-FORMAT.md
@@ -5,24 +5,24 @@ The `j` mode of `goxa` prints a JSON document describing the archive without ext
 ```json
 {
   "version": 2,
-  "flags": 16,
+  "flags": ["Checksums"],
   "compression": "zstd",
   "checksum": "blake3",
   "checksumLength": 32,
   "blockSize": 524288,
   "archiveSize": 12345,
   "dirs": [
-    { "path": "emptyDir", "mode": 493, "modTime": "2023-01-02T15:04:05Z" }
+    { "path": "emptyDir", "mode": 493, "modTime": 1672671845 }
   ],
   "files": [
     { "path": "file.txt", "type": "file", "size": 12,
-      "mode": 420, "modTime": "2023-01-02T15:04:05Z" }
+      "mode": 420, "modTime": 1672671845 }
   ]
 }
 ```
 
 * `version` – archive format version (`uint16`)
-* `flags` – feature flags (`uint32`)
+* `flags` – feature flags as an array of names
 * `compression` – compression algorithm name
 * `checksum` – checksum algorithm name
 * `checksumLength` – checksum size in bytes
@@ -30,7 +30,21 @@ The `j` mode of `goxa` prints a JSON document describing the archive without ext
 * `archiveSize` – total archive size in bytes
 * `dirs` – array of empty directory entries
 * `files` – array of file entries
+* `modTime` – seconds since the Unix epoch
 
 Each directory may include `mode` and `modTime` when stored. File entries contain a `path`, `type`, and `size` (except for `other` types). Symlinks and hardlinks include a `link` field with the target path. Optional `mode` and `modTime` fields appear when present in the archive.
 
 `flags`, `compression`, and `checksum` correspond to the tables in [FILE-FORMAT.md](FILE-FORMAT.md).
+The recognized flag names are:
+
+- "Absolute Paths" – store absolute paths
+- "Permissions" – preserve permissions
+- "Mod Dates" – preserve modification times
+- "Checksums" – include checksums
+- "No Compress" – disable compression
+- "Include Invis" – include hidden files
+- "Special Files" – archive symlinks and other special files
+- "Block Checksums" – store per-block checksums
+
+"None" is reserved and does not correspond to a feature. "Unknown" may appear when future flags are encountered.
+

--- a/bitFlag.go
+++ b/bitFlag.go
@@ -70,3 +70,14 @@ func flagLetters(flags BitFlags) string {
 	}
 	return out
 }
+
+// flagNamesList returns a slice of human-readable flag names.
+func flagNamesList(flags BitFlags) []string {
+	var out []string
+	for x := 0; 1<<x < fTop; x++ {
+		if flags.IsSet(1 << x) {
+			out = append(out, flagNames[x])
+		}
+	}
+	return out
+}

--- a/config.go
+++ b/config.go
@@ -59,3 +59,27 @@ type ArchiveListing struct {
 	Dirs           []ListEntry `json:"dirs"`
 	Files          []ListEntry `json:"files"`
 }
+
+// ListEntryOut is used for JSON output with Unix time.
+type ListEntryOut struct {
+	Path     string      `json:"path"`
+	Type     string      `json:"type"`
+	Size     uint64      `json:"size,omitempty"`
+	Mode     fs.FileMode `json:"mode,omitempty"`
+	ModTime  int64       `json:"modTime,omitempty"`
+	Linkname string      `json:"link,omitempty"`
+}
+
+// ArchiveListingOut mirrors ArchiveListing but uses
+// human-readable flags and Unix time.
+type ArchiveListingOut struct {
+	Version        uint16         `json:"version"`
+	Flags          []string       `json:"flags"`
+	Compression    string         `json:"compression"`
+	Checksum       string         `json:"checksum"`
+	ChecksumLength uint8          `json:"checksumLength"`
+	BlockSize      uint32         `json:"blockSize"`
+	ArchiveSize    uint64         `json:"archiveSize"`
+	Dirs           []ListEntryOut `json:"dirs"`
+	Files          []ListEntryOut `json:"files"`
+}

--- a/extract.go
+++ b/extract.go
@@ -318,9 +318,9 @@ func extract(destinations []string, listOnly bool, jsonList bool) {
 	}
 
 	if jsonList {
-		out := ArchiveListing{
+		out := ArchiveListingOut{
 			Version:        readVersion,
-			Flags:          lfeat,
+			Flags:          flagNamesList(lfeat),
 			Compression:    compName(ctype),
 			Checksum:       checksumName(checksumType),
 			ChecksumLength: checksumLength,
@@ -329,11 +329,11 @@ func extract(destinations []string, listOnly bool, jsonList bool) {
 		}
 		for _, item := range dirList {
 			if isSelected(item.Path) {
-				out.Dirs = append(out.Dirs, ListEntry{
+				out.Dirs = append(out.Dirs, ListEntryOut{
 					Path:    item.Path,
 					Type:    "dir",
 					Mode:    item.Mode,
-					ModTime: item.ModTime,
+					ModTime: item.ModTime.Unix(),
 				})
 			}
 		}
@@ -341,12 +341,12 @@ func extract(destinations []string, listOnly bool, jsonList bool) {
 			if !isSelected(item.Path) {
 				continue
 			}
-			out.Files = append(out.Files, ListEntry{
+			out.Files = append(out.Files, ListEntryOut{
 				Path:     item.Path,
 				Type:     entryName(item.Type),
 				Size:     item.Size,
 				Mode:     item.Mode,
-				ModTime:  item.ModTime,
+				ModTime:  item.ModTime.Unix(),
 				Linkname: item.Linkname,
 			})
 		}

--- a/json_list_test.go
+++ b/json_list_test.go
@@ -44,7 +44,7 @@ func TestCLIJSONList(t *testing.T) {
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 
-	var listing ArchiveListing
+	var listing ArchiveListingOut
 	if err := json.Unmarshal(buf.Bytes(), &listing); err != nil {
 		t.Fatalf("json decode: %v", err)
 	}


### PR DESCRIPTION
## Summary
- output feature flags as names instead of numbers
- use Unix epoch seconds for modTime fields
- document updated JSON format
- list available flag names
- adjust unit tests for new JSON structure

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6849205f991c832a9980fcb2243c44ac