### PR TITLE
Improve docs and add xz compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ GoXA is a small archiver written in Go. It's quick and friendly, though still le
 ## Features
 
 - Fast archive creation and extraction
-- Choice of gzip, zstd, lz4, s2, snappy, brotli or xz (default zstd)
+- Compression: gzip, zstd, lz4, s2, snappy, brotli or xz (default zstd)
 - Tar compatibility (auto-detected by filename or header)
 - Optional checksums: CRC32, CRC16, XXHash3, SHA-256 or Blake3 (default Blake3)
 - Preserve permissions and modification times
 - Fully documented binary format ([FILE-FORMAT.md](FILE-FORMAT.md))
 - Archive symlinks and other special files
-- Block-based compression for speed (single block when uncompressed)
+- Block-based compression for speed
 - Automatic format detection
 - Stream archives to stdout
 - Selective extraction with `-files`
@@ -49,12 +49,17 @@ See `goxa.1` for the full command reference.
 ## Usage
 
 ```bash
-goxa [mode] [flags] -arc=archiveFile [paths...]
+goxa [mode] [flags] -arc=FILE [paths...]
 ```
 
-`mode`: `c` (create), `l` (list), `j` (json list), `x` (extract)
+Modes are:
 
-`flags`: any combination of:
+* `c` – create an archive
+* `l` – list contents
+* `j` – JSON list
+* `x` – extract files
+
+Flags (combine as needed):
 
 | Flag | Description |
 |------|-------------|
@@ -86,26 +91,24 @@ Paths are stored relative by default. Use `a` to store and restore absolute path
 | `-version` | Print version and exit |
 
 Progress shows transfer speed and the current file being processed.
-
-`xz` compression is only available when `-format=tar`.
 Snappy does not support configurable compression levels; `-speed` has no effect when using snappy.
 
 ### Examples
 
 ```bash
-goxa -version
-goxa c -arc=mybackup.goxa myStuff/
-goxa capmsif -arc=mybackup.goxa ~/
-goxa x -arc=mybackup.goxa
-goxa xu -arc=mybackup.goxa     # use flags in archive (aka auto)
-goxa l -arc=mybackup.goxa
-goxa j -arc=mybackup.goxa > listing.json
-goxa c -arc=mybackup.tar.gz myStuff/
-goxa x -arc=mybackup.tar.gz
-goxa c -arc=mybackup.tar.xz myStuff/
-goxa x -arc=mybackup.tar.xz
-goxa c -arc=mybackup.goxa -stdout myStuff/ | ssh host "cat > backup.goxa"
-goxa x -arc=mybackup.goxa -files=file.txt,dir/
+goxa -version                                 # print version
+goxa c -arc=mybackup.goxa myStuff/            # create archive
+goxa capmsif -arc=mybackup.goxa ~/            # create using all flags
+goxa x -arc=mybackup.goxa                     # extract to folder
+goxa xu -arc=mybackup.goxa                    # extract using archive flags
+goxa l -arc=mybackup.goxa                     # list contents
+goxa j -arc=mybackup.goxa > listing.json      # JSON listing
+goxa c -arc=mybackup.tar.gz myStuff/          # create tar.gz
+goxa x -arc=mybackup.tar.gz                   # extract tar.gz
+goxa c -arc=mybackup.tar.xz myStuff/          # create tar.xz
+goxa x -arc=mybackup.tar.xz                   # extract tar.xz
+goxa c -arc=mybackup.goxa -stdout myStuff/ | ssh host "cat > backup.goxa"  # stream over SSH
+goxa x -arc=mybackup.goxa -files=file.txt,dir/ # selective extract
 ```
 
 ## Roadmap
@@ -114,6 +117,7 @@ goxa x -arc=mybackup.goxa -files=file.txt,dir/
 - [ ] Archive signatures for optional additional security
 - [ ] Archive comment field
 - [ ] Encrypted archives
+- [ ] Create goxa library
 
 ## Security Notes
 

--- a/compression_test.go
+++ b/compression_test.go
@@ -19,6 +19,7 @@ func TestAllCompressions(t *testing.T) {
 		{"s2", compS2, 0},
 		{"snappy", compSnappy, 0},
 		{"brotli", compBrotli, 0},
+		{"xz", compXZ, 0},
 		{"none", compGzip, fNoCompress},
 	}
 

--- a/const.go
+++ b/const.go
@@ -55,6 +55,7 @@ const (
 	compS2
 	compSnappy
 	compBrotli
+	compXZ
 )
 
 // Compression speed levels

--- a/create.go
+++ b/create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	gzip "github.com/klauspost/pgzip"
 	lz4 "github.com/pierrec/lz4/v4"
+	"github.com/ulikunitz/xz"
 )
 
 func compressor(w io.Writer) io.WriteCloser {
@@ -75,6 +76,12 @@ func compressor(w io.Writer) io.WriteCloser {
 			level = brotli.BestCompression
 		}
 		return brotli.NewWriterLevel(w, level)
+	case compXZ:
+		xzw, err := xz.NewWriter(w)
+		if err != nil {
+			log.Fatalf("xz init failed: %v", err)
+		}
+		return xzw
 	default:
 		lvl := gzip.BestSpeed
 		switch compSpeed {

--- a/extract.go
+++ b/extract.go
@@ -24,6 +24,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	lz4 "github.com/pierrec/lz4/v4"
 	"github.com/remeh/sizedwaitgroup"
+	"github.com/ulikunitz/xz"
 )
 
 func decompressor(r io.Reader, cType uint8) (io.ReadCloser, error) {
@@ -42,6 +43,12 @@ func decompressor(r io.Reader, cType uint8) (io.ReadCloser, error) {
 		return io.NopCloser(snappy.NewReader(r)), nil
 	case compBrotli:
 		return io.NopCloser(brotli.NewReader(r)), nil
+	case compXZ:
+		xr, err := xz.NewReader(r)
+		if err != nil {
+			return nil, err
+		}
+		return io.NopCloser(xr), nil
 	default:
 		gr, err := gzip.NewReader(r)
 		if err != nil {
@@ -65,6 +72,8 @@ func compName(t uint8) string {
 		return "snappy"
 	case compBrotli:
 		return "brotli"
+	case compXZ:
+		return "xz"
 	default:
 		return "gzip"
 	}

--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func main() {
 		if strings.ToLower(format) == "tar" {
 			tarUseXz = true
 		} else {
-			log.Fatalf("Unknown compression: %s", compression)
+			compType = compXZ
 		}
 	case "none":
 		features.Set(fNoCompress)


### PR DESCRIPTION
## Summary
- clarify feature list and usage section
- add notes to examples and new roadmap bullet for creating a GoXA library
- support xz compression for goxa archives
- update compression tests for xz

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684925ee8428832ab2236566157e071c