### PR TITLE
Improve docs and add xz compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ GoXA is a small archiver written in Go. It's quick and friendly, though still le
 ## Features
 
 - Fast archive creation and extraction
-- Choice of gzip, zstd, lz4, s2, snappy, brotli or xz (default zstd)
+- Compression: gzip, zstd, lz4, s2, snappy, brotli or xz (default zstd)
 - Tar compatibility (auto-detected by filename or header)
 - Optional checksums: CRC32, CRC16, XXHash3, SHA-256 or Blake3 (default Blake3)
 - Preserve permissions and modification times
 - Fully documented binary format ([FILE-FORMAT.md](FILE-FORMAT.md))
 - Archive symlinks and other special files
-- Block-based compression for speed (single block when uncompressed)
+- Block-based compression for speed
 - Automatic format detection
 - Stream archives to stdout
 - Selective extraction with `-files`
@@ -49,12 +49,17 @@ See `goxa.1` for the full command reference.
 ## Usage
 
 ```bash
-goxa [mode] [flags] -arc=archiveFile [paths...]
+goxa [mode] [flags] -arc=FILE [paths...]
 ```
 
-`mode`: `c` (create), `l` (list), `j` (json list), `x` (extract)
+Modes are:
 
-`flags`: any combination of:
+* `c` – create an archive
+* `l` – list contents
+* `j` – JSON list
+* `x` – extract files
+
+Flags (combine as needed):
 
 | Flag | Description |
 |------|-------------|
@@ -86,26 +91,24 @@ Paths are stored relative by default. Use `a` to store and restore absolute path
 | `-version` | Print version and exit |
 
 Progress shows transfer speed and the current file being processed.
-
-`xz` compression is only available when `-format=tar`.
 Snappy does not support configurable compression levels; `-speed` has no effect when using snappy.
 
 ### Examples
 
 ```bash
-goxa -version
-goxa c -arc=mybackup.goxa myStuff/
-goxa capmsif -arc=mybackup.goxa ~/
-goxa x -arc=mybackup.goxa
-goxa xu -arc=mybackup.goxa     # use flags in archive (aka auto)
-goxa l -arc=mybackup.goxa
-goxa j -arc=mybackup.goxa > listing.json
-goxa c -arc=mybackup.tar.gz myStuff/
-goxa x -arc=mybackup.tar.gz
-goxa c -arc=mybackup.tar.xz myStuff/
-goxa x -arc=mybackup.tar.xz
-goxa c -arc=mybackup.goxa -stdout myStuff/ | ssh host "cat > backup.goxa"
-goxa x -arc=mybackup.goxa -files=file.txt,dir/
+goxa -version                                 # print version
+goxa c -arc=mybackup.goxa myStuff/            # create archive
+goxa capmsif -arc=mybackup.goxa ~/            # create using all flags
+goxa x -arc=mybackup.goxa                     # extract to folder
+goxa xu -arc=mybackup.goxa                    # extract using archive flags
+goxa l -arc=mybackup.goxa                     # list contents
+goxa j -arc=mybackup.goxa > listing.json      # JSON listing
+goxa c -arc=mybackup.tar.gz myStuff/          # create tar.gz
+goxa x -arc=mybackup.tar.gz                   # extract tar.gz
+goxa c -arc=mybackup.tar.xz myStuff/          # create tar.xz
+goxa x -arc=mybackup.tar.xz                   # extract tar.xz
+goxa c -arc=mybackup.goxa -stdout myStuff/ | ssh host "cat > backup.goxa"  # stream over SSH
+goxa x -arc=mybackup.goxa -files=file.txt,dir/ # selective extract
 ```
 
 ## Roadmap
@@ -114,6 +117,13 @@ goxa x -arc=mybackup.goxa -files=file.txt,dir/
 - [ ] Archive signatures for optional additional security
 - [ ] Archive comment field
 - [ ] Encrypted archives
+- [ ] Create goxa library
+
+## Testing
+
+`go test ./...` runs the built-in unit and integration tests. The
+`test-goxa.sh` script builds the CLI and performs real-world archive
+creation and extraction checks.
 
 ## Security Notes
 

--- a/compression_test.go
+++ b/compression_test.go
@@ -19,6 +19,7 @@ func TestAllCompressions(t *testing.T) {
 		{"s2", compS2, 0},
 		{"snappy", compSnappy, 0},
 		{"brotli", compBrotli, 0},
+		{"xz", compXZ, 0},
 		{"none", compGzip, fNoCompress},
 	}
 

--- a/const.go
+++ b/const.go
@@ -55,6 +55,7 @@ const (
 	compS2
 	compSnappy
 	compBrotli
+	compXZ
 )
 
 // Compression speed levels

--- a/create.go
+++ b/create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	gzip "github.com/klauspost/pgzip"
 	lz4 "github.com/pierrec/lz4/v4"
+	"github.com/ulikunitz/xz"
 )
 
 func compressor(w io.Writer) io.WriteCloser {
@@ -75,6 +76,12 @@ func compressor(w io.Writer) io.WriteCloser {
 			level = brotli.BestCompression
 		}
 		return brotli.NewWriterLevel(w, level)
+	case compXZ:
+		xzw, err := xz.NewWriter(w)
+		if err != nil {
+			log.Fatalf("xz init failed: %v", err)
+		}
+		return xzw
 	default:
 		lvl := gzip.BestSpeed
 		switch compSpeed {

--- a/extract.go
+++ b/extract.go
@@ -24,6 +24,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	lz4 "github.com/pierrec/lz4/v4"
 	"github.com/remeh/sizedwaitgroup"
+	"github.com/ulikunitz/xz"
 )
 
 func decompressor(r io.Reader, cType uint8) (io.ReadCloser, error) {
@@ -42,6 +43,12 @@ func decompressor(r io.Reader, cType uint8) (io.ReadCloser, error) {
 		return io.NopCloser(snappy.NewReader(r)), nil
 	case compBrotli:
 		return io.NopCloser(brotli.NewReader(r)), nil
+	case compXZ:
+		xr, err := xz.NewReader(r)
+		if err != nil {
+			return nil, err
+		}
+		return io.NopCloser(xr), nil
 	default:
 		gr, err := gzip.NewReader(r)
 		if err != nil {
@@ -65,6 +72,8 @@ func compName(t uint8) string {
 		return "snappy"
 	case compBrotli:
 		return "brotli"
+	case compXZ:
+		return "xz"
 	default:
 		return "gzip"
 	}

--- a/main.go
+++ b/main.go
@@ -33,8 +33,30 @@ func main() {
 		fmt.Println("\nError: No mode specified.")
 		return
 	}
+
+	if strings.HasPrefix(os.Args[1], "-") {
+		fs := flag.NewFlagSet("goxa", flag.ExitOnError)
+		var showVer bool
+		var showHelp bool
+		fs.BoolVar(&showVer, "version", false, "print version and exit")
+		fs.BoolVar(&showHelp, "help", false, "show help")
+		fs.BoolVar(&showHelp, "h", false, "show help")
+		fs.Parse(os.Args[1:])
+		if showVer {
+			fmt.Println(version)
+			return
+		}
+		showUsage()
+		return
+	}
+
 	cmd := strings.ToLower(os.Args[1])
 	cmdLetter := cmd[0]
+	if !strings.ContainsRune("cljx", rune(cmdLetter)) {
+		showUsage()
+		fmt.Printf("\nError: Unknown mode: %s\n", cmd)
+		return
+	}
 	opts := ""
 	if len(cmd) > 1 {
 		opts = cmd[1:]
@@ -145,7 +167,7 @@ func main() {
 		if strings.ToLower(format) == "tar" {
 			tarUseXz = true
 		} else {
-			log.Fatalf("Unknown compression: %s", compression)
+			compType = compXZ
 		}
 	case "none":
 		features.Set(fNoCompress)
@@ -231,34 +253,43 @@ func main() {
 }
 
 func showUsage() {
-	fmt.Println("Usage: goxa [c|l|j|x][apmsnbiveou] -arc=arcFile [-comp=alg] [input paths/files...] or [destination]")
-	fmt.Println("Output archive to stdout: -stdout, No progress bar: -progress=false")
-	fmt.Println("\nModes:")
-	fmt.Println("  c = Create a new archive. Requires input paths or files")
-	fmt.Println("  l = List archive contents. Requires -arc")
-	fmt.Println("  j = JSON list of archive contents. Requires -arc")
-	fmt.Println("  x = Extract files from archive. Requires -arc")
+	fmt.Println("Usage:")
+	fmt.Println("  goxa [mode] [flags] -arc=FILE [paths...]")
 
-	fmt.Println("\nOptions:")
-	fmt.Print("  a = Absolute paths	")
-	fmt.Println("  p = Permissions")
-	fmt.Print("  m = Modification date	")
-	fmt.Println("  s = File sums")
-	fmt.Print("  b = Block sums            ")
-	fmt.Print("  n = No-compression	")
-	fmt.Println("  i = Include dotfiles")
-	fmt.Print("  o = Special files          ")
-	fmt.Println("  u = Use archive flags")
-	fmt.Println("  v = Verbose logging")
-	fmt.Print("  f = Force (overwrite files and ignore read errors)")
-	fmt.Println("  -comp=gzip|zstd|lz4|s2|snappy|brotli|xz|none")
-	fmt.Println("  -speed=fastest|default|better|best")
-	fmt.Println("  -format=tar|goxa")
-	fmt.Println("  -version")
-	fmt.Println()
-	fmt.Println("  goxa c -arc=arcFile myStuff		(similar to zip)")
-	fmt.Println("  goxa cpmi -arc=arcFile myStuff	(similar to tar -czf)")
-	fmt.Println("")
-	fmt.Println("  goxa x -arc=arcFile			(similar to unzip)")
-	fmt.Println("  goxa xpmi -arc=arcFile		(similar to tar -xzf)")
+	fmt.Println("\nModes:")
+	fmt.Println("  c - create an archive")
+	fmt.Println("  l - list contents")
+	fmt.Println("  j - JSON list")
+	fmt.Println("  x - extract files")
+
+	fmt.Println("\nFlags:")
+	fmt.Print("  a = Absolute paths          ")
+	fmt.Println("p = File permissions")
+	fmt.Print("  m = Modification times      ")
+	fmt.Println("s = Enable checksums")
+	fmt.Print("  b = Block checksums         ")
+	fmt.Println("n = Disable compression")
+	fmt.Print("  i = Hidden files            ")
+	fmt.Println("o = Special files")
+	fmt.Print("  u = Use archive flags       ")
+	fmt.Println("v = Verbose logging")
+	fmt.Println("  f = Force overwrite/ignore errors")
+
+	fmt.Println("\nExtra flags:")
+	fmt.Println("  -arc=FILE       Archive file name")
+	fmt.Println("  -stdout         Output archive to stdout")
+	fmt.Println("  -files=LIST     Files/directories to extract")
+	fmt.Println("  -progress=false Disable progress display")
+	fmt.Println("  -comp=ALG       Compression algorithm (gzip, zstd, lz4, s2, snappy, brotli, xz, none)")
+	fmt.Println("  -speed=LEVEL    Compression speed (fastest, default, better, best)")
+	fmt.Println("  -format=FORMAT  Archive format (goxa or tar)")
+	fmt.Println("  -version        Print version and exit")
+
+	fmt.Println("\nExamples:")
+	fmt.Println("  goxa -version                                 # print version")
+	fmt.Println("  goxa c -arc=mybackup.goxa myStuff/            # create archive")
+	fmt.Println("  goxa x -arc=mybackup.goxa                     # extract to folder")
+	fmt.Println("  goxa l -arc=mybackup.goxa                     # list contents")
+	fmt.Println("  goxa c -arc=mybackup.tar.gz myStuff/          # create tar.gz")
+	fmt.Println("  goxa x -arc=mybackup.tar.xz                   # extract tar.xz")
 }


### PR DESCRIPTION
## Summary
- clarify feature list and usage section
- add notes to examples and new roadmap bullet for creating a GoXA library
- support xz compression for goxa archives
- update compression tests for xz
- mention test suite in README
- show help when no args or invalid mode supplied and improve help text

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684925ee8428832ab2236566157e071c