### PR TITLE
Update docs for consistent flags and options

### DIFF
--- a/JSON-LIST-FORMAT.md
+++ b/JSON-LIST-FORMAT.md
@@ -39,10 +39,10 @@ The recognized flag names are:
 
 - "Absolute Paths" – store absolute paths
 - "Permissions" – preserve permissions
-- "Mod Dates" – preserve modification times
-- "Checksums" – include checksums
-- "No Compress" – disable compression
-- "Include Invis" – include hidden files
+ - "Modification Times" – preserve modification times
+ - "Checksums" – include checksums
+ - "No Compress" – disable compression
+ - "Hidden Files" – include hidden files
 - "Special Files" – archive symlinks and other special files
 - "Block Checksums" – store per-block checksums
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ creation and extraction checks.
 
 - Paths are sanitized during extraction, but `-a` (`absolute paths`) allows the archive to write anywhere. Use with care on unknown files.
 - With `-o` (`special files`) symlinks are not resolved, so sneaky links can sidestep your destination folder.
-- `-u` (`use flags from archive`) applies whatever options were set when the archive was created, which may enable absolute paths, permissions, mod dates and special files.
+ - `-u` (`use flags from archive`) applies whatever options were set when the archive was created, which may enable absolute paths, permissions, modification times and special files.
 - Size fields use `int64`; maximum individual file size is about 9,223 petabytes (~8&nbsp;EiB).
 
 ## License

--- a/const.go
+++ b/const.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	flagNames = []string{"None", "Absolute Paths", "Permissions", "Mod Dates", "Checksums", "No Compress", "Include Invis", "Special Files", "Block Checksums", "Unknown"}
+	flagNames = []string{"None", "Absolute Paths", "Permissions", "Modification Times", "Checksums", "No Compress", "Hidden Files", "Special Files", "Block Checksums", "Unknown"}
 )
 
 // Entry Types

--- a/goxa.1
+++ b/goxa.1
@@ -11,6 +11,9 @@ goxa \- fast archiving tool written in Go
 .B goxa l
 .RI "[flags] -arc=FILE"
 .br
+.B goxa j
+.RI "[flags] -arc=FILE"
+.br
 .B goxa x
 .RI "[flags] -arc=FILE [destination]"
 .SH DESCRIPTION
@@ -22,6 +25,9 @@ Create a new archive.
 .TP
 .B l
 List archive contents.
+.TP
+.B j
+JSON list of archive contents.
 .TP
 .B x
 Extract files from an archive.
@@ -83,6 +89,9 @@ Compression speed (fastest, default, better, best).
 .TP
 .BI -format= TYPE
 Archive format (goxa or tar).
+.TP
+.B -version
+Print version and exit.
 .SH EXAMPLES
 .nf
 goxa c -arc=backup.goxa mydir/


### PR DESCRIPTION
## Summary
- document `j` mode and `-version` in the man page
- match README security note wording
- sync JSON format docs with help text
- rename flag names in code for consistency

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68492e15f8a4832abf6123d64dbc53c8