### PR TITLE
Allow uint64 block sizes

### DIFF
--- a/FILE-FORMAT.md
+++ b/FILE-FORMAT.md
@@ -110,7 +110,7 @@ The trailer starts at the offset recorded in the header. Layout:
 
 ```
 [Block Count uint32]
-[ [Offset uint64][Size uint32] ... ]
+[ [Offset uint64][Size uint64] ... ]
 [Trailer Checksum: checksum length from header]
 ```
 

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ type FileEntry struct {
 
 type Block struct {
 	Offset uint64
-	Size   uint32
+	Size   uint64
 }
 
 type ListEntry struct {

--- a/create.go
+++ b/create.go
@@ -354,7 +354,7 @@ func writeEntries(headerLen int, bf *BufferedFile, files []FileEntry) uint64 {
 				written = uint64(cw.Count())
 			}
 			cOffset += written
-			blocks = append(blocks, Block{Offset: bOff, Size: uint32(written)})
+			blocks = append(blocks, Block{Offset: bOff, Size: written})
 		} else {
 			for {
 				n, err := io.ReadFull(br, buf)
@@ -365,7 +365,7 @@ func writeEntries(headerLen int, bf *BufferedFile, files []FileEntry) uint64 {
 							log.Fatalf("copy failed: %v", err)
 						}
 						cOffset += uint64(n)
-						blocks = append(blocks, Block{Offset: bOff, Size: uint32(n)})
+						blocks = append(blocks, Block{Offset: bOff, Size: uint64(n)})
 					} else {
 						cw := &countingWriter{w: bf}
 						zw := compressor(cw)
@@ -376,7 +376,7 @@ func writeEntries(headerLen int, bf *BufferedFile, files []FileEntry) uint64 {
 							log.Fatalf("compress close failed: %v", err)
 						}
 						cOffset += uint64(cw.Count())
-						blocks = append(blocks, Block{Offset: bOff, Size: uint32(cw.Count())})
+						blocks = append(blocks, Block{Offset: bOff, Size: uint64(cw.Count())})
 					}
 				}
 				if err == io.EOF {


### PR DESCRIPTION
## Summary
- support larger block size by making the block `Size` field a uint64
- document this change in `FILE-FORMAT`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68492ec2973c832ab6858df85a9cc472