### PR TITLE
Improve base32/64 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ GoXA is a small archiver written in Go. It's quick and friendly, though still le
 - Selective extraction with `-files`
 - Progress bar with transfer speed and current file
 - Pure Go code—no runtime deps once built
-- Base32/64 encoding via `.b32`/`.b64` suffix
+- Base32/64 encoding when the archive filename ends with `.b32` or `.b64`
 
 ## File Format
 
@@ -92,6 +92,18 @@ Paths are stored relative by default. Use `a` to store and restore absolute path
 
 Progress shows transfer speed and the current file being processed.
 Snappy does not support configurable compression levels; `-speed` has no effect when using snappy.
+
+### Base32/Base64 Archives
+
+Appending `.b32` or `.b64` to the archive filename encodes the output in Base32
+or Base64. The same suffix triggers automatic decoding when extracting or
+listing. For example:
+
+```bash
+goxa c -arc=mybackup.goxa.b64 myStuff/  # create Base64 encoded archive
+goxa x -arc=mybackup.goxa.b64           # extract encoded archive
+goxa c -arc=mybackup.goxa.b32 myStuff/  # create Base32 encoded archive
+```
 
 ### Examples
 

--- a/goxa.1
+++ b/goxa.1
@@ -92,11 +92,16 @@ Archive format (goxa or tar).
 .TP
 .B -version
 Print version and exit.
+.SS BASE32/BASE64
+Filenames ending with \fB.b32\fP or \fB.b64\fP are encoded using
+Base32 or Base64 and automatically decoded on extract or list.
 .SH EXAMPLES
 .nf
 goxa c -arc=backup.goxa mydir/
 goxa capmsf -arc=backup.goxa ~/docs
 goxa x -arc=backup.goxa
+goxa c -arc=backup.goxa.b64 mydir/
+goxa x -arc=backup.goxa.b64
 .fi
 .SH SEE ALSO
 tar(1), gzip(1)

--- a/main.go
+++ b/main.go
@@ -284,6 +284,7 @@ func showUsage() {
 	fmt.Println("  -speed=LEVEL    Compression speed (fastest, default, better, best)")
 	fmt.Println("  -format=FORMAT  Archive format (goxa or tar)")
 	fmt.Println("  -version        Print version and exit")
+	fmt.Println("  (append .b32 or .b64 to -arc for Base32 or Base64 encoding)")
 
 	fmt.Println("\nExamples:")
 	fmt.Println("  goxa -version                                 # print version")
@@ -292,4 +293,6 @@ func showUsage() {
 	fmt.Println("  goxa l -arc=mybackup.goxa                     # list contents")
 	fmt.Println("  goxa c -arc=mybackup.tar.gz myStuff/          # create tar.gz")
 	fmt.Println("  goxa x -arc=mybackup.tar.xz                   # extract tar.xz")
+	fmt.Println("  goxa c -arc=mybackup.goxa.b64 myStuff/        # create Base64 encoded")
+	fmt.Println("  goxa x -arc=mybackup.goxa.b64                 # extract encoded archive")
 }


### PR DESCRIPTION
## Summary
- document base32/b64 encoding on the README feature list
- explain `.b32`/`.b64` archives in README usage section
- mention base32/b64 encoding in command help
- add man page section describing encoded archives

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68492f868728832aa27348441fcebd69