### PR TITLE
Expand integration test coverage

### DIFF
--- a/test-goxa.sh
+++ b/test-goxa.sh
@@ -118,4 +118,80 @@ fi
 
 echo "archive create/extract without compression passed"
 
+# --- Test Base64 encoding ---
+"$GOXA" cpmsi -arc "$TMPDIR/test_b64.goxa.b64" "$SRC"
+mv "$SRC" "$SRC.orig_b64"
+"$GOXA" xpmsi -arc "$TMPDIR/test_b64.goxa.b64" "$OUT/b64"
+EXTRACTED_B64="$OUT/b64/$ORIG_NAME"
+
+orig_files=$(find "$SRC.orig_b64" -type f | wc -l)
+extr_files=$(find "$EXTRACTED_B64" -type f | wc -l)
+if [ "$orig_files" -ne "$extr_files" ]; then
+  echo "file count mismatch (base64)" >&2
+  exit 1
+fi
+
+orig_perm=$(stat -c %a "$SRC.orig_b64/.hidden")
+extr_perm=$(stat -c %a "$EXTRACTED_B64/.hidden")
+if [ "$orig_perm" != "$extr_perm" ]; then
+  echo "permission mismatch (base64)" >&2
+  exit 1
+fi
+
+orig_time=$(stat -c %Y "$SRC.orig_b64/file_1.bin")
+extr_time=$(stat -c %Y "$EXTRACTED_B64/file_1.bin")
+if [ "$orig_time" != "$extr_time" ]; then
+  echo "mod time mismatch (base64)" >&2
+  exit 1
+fi
+
+orig_sum=$(sha256sum "$SRC.orig_b64/file_1.bin" | cut -d" " -f1)
+extr_sum=$(sha256sum "$EXTRACTED_B64/file_1.bin" | cut -d" " -f1)
+if [ "$orig_sum" != "$extr_sum" ]; then
+  echo "checksum mismatch (base64)" >&2
+  exit 1
+fi
+
+echo "archive create/extract with base64 encoding passed"
+
+mv "$SRC.orig_b64" "$SRC"  # Restore for next test
+
+# --- Test FEC encoding ---
+"$GOXA" cpmsi -arc "$TMPDIR/test_fec.goxaf" "$SRC"
+mv "$SRC" "$SRC.orig_fec"
+"$GOXA" xpmsi -arc "$TMPDIR/test_fec.goxaf" "$OUT/fec"
+EXTRACTED_FEC="$OUT/fec/$ORIG_NAME"
+
+orig_files=$(find "$SRC.orig_fec" -type f | wc -l)
+extr_files=$(find "$EXTRACTED_FEC" -type f | wc -l)
+if [ "$orig_files" -ne "$extr_files" ]; then
+  echo "file count mismatch (fec)" >&2
+  exit 1
+fi
+
+orig_perm=$(stat -c %a "$SRC.orig_fec/.hidden")
+extr_perm=$(stat -c %a "$EXTRACTED_FEC/.hidden")
+if [ "$orig_perm" != "$extr_perm" ]; then
+  echo "permission mismatch (fec)" >&2
+  exit 1
+fi
+
+orig_time=$(stat -c %Y "$SRC.orig_fec/file_1.bin")
+extr_time=$(stat -c %Y "$EXTRACTED_FEC/file_1.bin")
+if [ "$orig_time" != "$extr_time" ]; then
+  echo "mod time mismatch (fec)" >&2
+  exit 1
+fi
+
+orig_sum=$(sha256sum "$SRC.orig_fec/file_1.bin" | cut -d" " -f1)
+extr_sum=$(sha256sum "$EXTRACTED_FEC/file_1.bin" | cut -d" " -f1)
+if [ "$orig_sum" != "$extr_sum" ]; then
+  echo "checksum mismatch (fec)" >&2
+  exit 1
+fi
+
+echo "archive create/extract with FEC encoding passed"
+
+mv "$SRC.orig_fec" "$SRC"  # Restore for go tests
+
 go test


### PR DESCRIPTION
## Summary
- add base64 and FEC encode/decode checks to `test-goxa.sh`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6849b4c68068832a9ba0b4441578b9dc