### PR TITLE
Add interactive prompt for extraction flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ Longer options use the usual `-flag=value` form.
 | `f` | force overwrite / ignore read errors |
 
 When extracting, the program prompts if the archive was created with
-flags you did not specify. Use `-interactive=false` to skip prompts.
+flags you did not specify. It will ask which missing flags to enable, or
+`u` to enable all. Press Enter to continue without them. Use
+`-interactive=false` to skip prompts.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Longer options use the usual `-flag=value` form.
 | `v` | verbose output |
 | `f` | force overwrite / ignore read errors |
 
+When extracting, the program prompts if the archive was created with
+flags you did not specify. Use `-interactive=false` to skip prompts.
+
 ### Options
 
 | Option | Description |
@@ -89,6 +92,7 @@ Longer options use the usual `-flag=value` form.
 | `-stdout` | write archive to stdout |
 | `-files` | comma-separated list to extract |
 | `-progress=false` | disable progress display |
+| `-interactive=false` | disable prompts for archive flags |
 | `-comp` | compression algorithm |
 | `-speed` | compression speed level |
 | `-format` | force `goxa` or `tar` format |

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 var (
 	archivePath                              string
 	verboseMode, doForce, toStdOut, progress bool
+	interactiveMode                          bool = true
 	features                                 BitFlags
 	useArchiveFlags                          bool
 	compression                              string

--- a/extract.go
+++ b/extract.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"encoding/binary"
@@ -192,27 +193,52 @@ func extract(destinations []string, listOnly bool, jsonList bool) {
 		features |= lfeat
 	} else {
 		missing := ""
+		missingFlags := BitFlags(0)
 		if lfeat.IsSet(fPermissions) && features.IsNotSet(fPermissions) {
 			missing += "p"
+			missingFlags |= fPermissions
 		}
 		if lfeat.IsSet(fModDates) && features.IsNotSet(fModDates) {
 			missing += "m"
+			missingFlags |= fModDates
 		}
 		if lfeat.IsSet(fSpecialFiles) && features.IsNotSet(fSpecialFiles) {
 			missing += "o"
+			missingFlags |= fSpecialFiles
 		}
 		if lfeat.IsSet(fIncludeInvis) && features.IsNotSet(fIncludeInvis) {
 			missing += "i"
+			missingFlags |= fIncludeInvis
 		}
 		if missing != "" {
 			if interactiveMode {
-				fmt.Printf("Archive uses flags '%s'. Continue? [Y/n] ", missing)
-				var resp string
-				fmt.Scanln(&resp)
+				fmt.Printf("Archive uses flags '%s'. Enable which? (letters or 'u'=all) [none]: ", missing)
+				reader := bufio.NewReader(os.Stdin)
+				resp, _ := reader.ReadString('\n')
 				resp = strings.TrimSpace(strings.ToLower(resp))
-				if resp == "n" || resp == "no" {
-					arc.Close()
-					return
+				if resp == "u" {
+					features |= missingFlags
+				} else {
+					for _, r := range resp {
+						switch r {
+						case 'p':
+							if missingFlags.IsSet(fPermissions) {
+								features.Set(fPermissions)
+							}
+						case 'm':
+							if missingFlags.IsSet(fModDates) {
+								features.Set(fModDates)
+							}
+						case 'o':
+							if missingFlags.IsSet(fSpecialFiles) {
+								features.Set(fSpecialFiles)
+							}
+						case 'i':
+							if missingFlags.IsSet(fIncludeInvis) {
+								features.Set(fIncludeInvis)
+							}
+						}
+					}
 				}
 			} else {
 				doLog(false, "Archive uses flags '%s'.", missing)

--- a/extract.go
+++ b/extract.go
@@ -205,9 +205,18 @@ func extract(destinations []string, listOnly bool, jsonList bool) {
 			missing += "i"
 		}
 		if missing != "" {
-			doLog(false, "Archive uses flags '%s'. Rerun with these flags or 'u' to auto-enable.", missing)
-			arc.Close()
-			return
+			if interactiveMode {
+				fmt.Printf("Archive uses flags '%s'. Continue? [Y/n] ", missing)
+				var resp string
+				fmt.Scanln(&resp)
+				resp = strings.TrimSpace(strings.ToLower(resp))
+				if resp == "n" || resp == "no" {
+					arc.Close()
+					return
+				}
+			} else {
+				doLog(false, "Archive uses flags '%s'.", missing)
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func main() {
 	flagSet.StringVar(&archivePath, "arc", defaultArchiveName, "archive file name (extension not required)")
 	flagSet.BoolVar(&toStdOut, "stdout", false, "output archive data to stdout")
 	flagSet.BoolVar(&progress, "progress", true, "show progress bar")
+	flagSet.BoolVar(&interactiveMode, "interactive", true, "prompt when archive uses extra flags")
 	var speedOpt string
 	flagSet.StringVar(&compression, "comp", "zstd", "compression: gzip|zstd|lz4|s2|snappy|brotli|xz|none")
 	flagSet.StringVar(&speedOpt, "speed", "fastest", "compression speed: fastest|default|better|best")
@@ -301,6 +302,7 @@ func showUsage() {
 	fmt.Println("  -stdout         write archive to stdout")
 	fmt.Println("  -files LIST     comma separated files to extract")
 	fmt.Println("  -progress=false disable progress display")
+	fmt.Println("  -interactive=false disable prompts for archive flags")
 	fmt.Println("  -comp ALG       compression algorithm (gzip, zstd, lz4, s2, snappy, brotli, xz, none)")
 	fmt.Println("  -speed LEVEL    compression speed (fastest, default, better, best)")
 	fmt.Println("  -format FORMAT  archive format (goxa or tar)")


### PR DESCRIPTION
## Summary
- allow extraction when flags don't match
- prompt user about extra archive flags by default
- add `-interactive` option to disable prompts
- document interactive extraction in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6849b6e0c1c4832abeaf8468898a0552