### PR TITLE
Fix default destination for encoded archives

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -125,7 +125,7 @@ func extract(destinations []string, listOnly bool, jsonList bool) {
 		pwd = path.Clean(pwd)
 
 		archiveName := path.Base(archivePath)
-		archiveName = strings.TrimRight(archiveName, ".goxa")
+		archiveName = stripArchiveExt(archiveName)
 		destination = path.Clean(pwd + "/" + archiveName + "/")
 	}
 

--- a/test-goxa.sh
+++ b/test-goxa.sh
@@ -159,8 +159,10 @@ mv "$SRC.orig_b64" "$SRC"  # Restore for next test
 # --- Test FEC encoding ---
 "$GOXA" cpmsi -arc "$TMPDIR/test_fec.goxaf" "$SRC"
 mv "$SRC" "$SRC.orig_fec"
-"$GOXA" xpmsi -arc "$TMPDIR/test_fec.goxaf" "$OUT/fec"
-EXTRACTED_FEC="$OUT/fec/$ORIG_NAME"
+pushd "$OUT" >/dev/null
+"$GOXA" xpmsi -arc "$TMPDIR/test_fec.goxaf"
+popd >/dev/null
+EXTRACTED_FEC="$OUT/test_fec/$ORIG_NAME"
 
 orig_files=$(find "$SRC.orig_fec" -type f | wc -l)
 extr_files=$(find "$EXTRACTED_FEC" -type f | wc -l)


### PR DESCRIPTION
## Summary
- use `stripArchiveExt` when deriving default extract directory

This ensures archives encoded with `.b32`/`.b64` extensions extract to folders named after the underlying archive file.

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849be2e9a64832aa69e826f5c71f23d