### PR TITLE
Improve FEC decode feedback

### DIFF
--- a/progress_writer.go
+++ b/progress_writer.go
@@ -1,0 +1,17 @@
+package main
+
+import "io"
+
+// progressWriter wraps an io.Writer and increments progress counters for bytes written.
+type progressWriter struct {
+	w io.Writer
+	p *progressData
+}
+
+func (pw progressWriter) Write(b []byte) (int, error) {
+	n, err := pw.w.Write(b)
+	if pw.p != nil {
+		pw.p.current.Add(int64(n))
+	}
+	return n, err
+}


### PR DESCRIPTION
## Summary
- show progress while decoding FEC archives
- add a progressWriter helper
- display a temporary message when reading archive headers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849dabe833c832a8ca8a7bd05ac0d2b