### PR TITLE
Add progress bars for encoding/decoding

### DIFF
--- a/create.go
+++ b/create.go
@@ -193,6 +193,12 @@ func create(inputPaths []string) error {
 			}
 			defer os.Remove(tmpPath)
 
+			info, err := src.Stat()
+			if err != nil {
+				src.Close()
+				log.Fatalf("stat tmp: %v", err)
+			}
+
 			var dst io.Writer
 			var encW io.WriteCloser
 			if toStdOut {
@@ -210,11 +216,19 @@ func create(inputPaths []string) error {
 			} else {
 				encW = base64.NewEncoder(base64.StdEncoding, dst)
 			}
-			if _, err := io.Copy(encW, src); err != nil {
+
+			p, done, finished := progressTicker(&progressData{total: info.Size(), speedWindowSize: time.Second * 5})
+			p.file.Store(archivePath)
+
+			if _, err := io.Copy(encW, progressReader{r: src, p: p}); err != nil {
+				close(done)
+				<-finished
 				log.Fatalf("encode copy: %v", err)
 			}
 			encW.Close()
 			src.Close()
+			close(done)
+			<-finished
 
 			if !toStdOut {
 				if st, err := os.Stat(archivePath); err == nil {

--- a/progress_writer.go
+++ b/progress_writer.go
@@ -12,6 +12,7 @@ func (pw progressWriter) Write(b []byte) (int, error) {
 	n, err := pw.w.Write(b)
 	if pw.p != nil {
 		pw.p.current.Add(int64(n))
+		pw.p.written.Add(int64(n))
 	}
 	return n, err
 }

--- a/util.go
+++ b/util.go
@@ -117,16 +117,24 @@ func decodeIfNeeded(name string) (string, func(), error) {
 	}
 	defer f.Close()
 
+	info, err := f.Stat()
+	if err != nil {
+		return "", nil, err
+	}
+
 	tmp, err := os.CreateTemp("", "goxa_dec_*")
 	if err != nil {
 		return "", nil, err
 	}
 
-	var r io.Reader = f
+	p, done, finished := progressTicker(&progressData{total: info.Size(), speedWindowSize: time.Second * 5})
+	p.file.Store(name)
+
+	var r io.Reader = progressReader{r: f, p: p}
 	if encode == "b32" {
-		r = base32.NewDecoder(base32.StdEncoding, f)
+		r = base32.NewDecoder(base32.StdEncoding, r)
 	} else if encode == "b64" {
-		r = base64.NewDecoder(base64.StdEncoding, f)
+		r = base64.NewDecoder(base64.StdEncoding, r)
 	} else if encode == "fec" {
 		f.Close()
 		os.Remove(tmp.Name())
@@ -135,9 +143,13 @@ func decodeIfNeeded(name string) (string, func(), error) {
 	if _, err := io.Copy(tmp, r); err != nil {
 		tmp.Close()
 		os.Remove(tmp.Name())
+		close(done)
+		<-finished
 		return "", nil, err
 	}
 	tmp.Close()
+	close(done)
+	<-finished
 	return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
 }
 


### PR DESCRIPTION
## Summary
- count written bytes in progress writer
- show progress when FEC-encoding archives
- add progress display for base32/base64 decoding
- display progress for base32/base64 encoding

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6849e4a8bf18832a97d006fa56179a70