### PR TITLE
Add throughput display and avg speed

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -129,7 +129,7 @@ func printProgress(p *progressData) {
 	fileName = filepath.Base(fileName)
 
 	// Build the informational part of the line and determine the bar width
-	info := fmt.Sprintf(" %3.2f%% %v/s %s", progress*100, humanize.Bytes(uint64(speed)), fileName)
+	info := fmt.Sprintf(" %3.2f%% %v/s avg %v/s %s", progress*100, humanize.Bytes(uint64(speed)), humanize.Bytes(uint64(avgSpeed)), fileName)
 	width := getLineWidth()
 	barWidth := width - len(info) - 2 // 2 for the surrounding []
 	if barWidth > maxBarWidth {

--- a/progress_reader.go
+++ b/progress_reader.go
@@ -12,6 +12,7 @@ func (pr progressReader) Read(b []byte) (int, error) {
 	n, err := pr.r.Read(b)
 	if pr.p != nil {
 		pr.p.current.Add(int64(n))
+		pr.p.written.Add(int64(n))
 	}
 	return n, err
 }

--- a/progress_writer.go
+++ b/progress_writer.go
@@ -12,6 +12,7 @@ func (pw progressWriter) Write(b []byte) (int, error) {
 	n, err := pw.w.Write(b)
 	if pw.p != nil {
 		pw.p.current.Add(int64(n))
+		pw.p.written.Add(int64(n))
 	}
 	return n, err
 }


### PR DESCRIPTION
## Summary
- ensure progress reader updates written bytes
- display current and average throughput in progress bar

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6849e4a8bf18832a97d006fa56179a70