### PR TITLE
Fix archive size log output

### DIFF
--- a/create.go
+++ b/create.go
@@ -203,11 +203,12 @@ func create(inputPaths []string) error {
 			}
 			defer os.Remove(tmpPath)
 
-			info, err := src.Stat()
+			st, err := src.Stat()
 			if err != nil {
 				src.Close()
 				log.Fatalf("stat tmp: %v", err)
 			}
+			info = st
 
 			var dst io.Writer
 			var encW io.WriteCloser


### PR DESCRIPTION
## Summary
- fix variable scoping so final archive size is logged from the encoded file

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6849f83d6628832a961f658db65678db