### PR TITLE
Clean up benchmark script

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,20 +1,29 @@
 #!/usr/bin/env bash
 # Re-run this script with bash if not already using bash
 if [ -z "${BASH_VERSION:-}" ]; then
-    echo "🔁 Not running under bash. Re-executing with bash..."
     exec bash "$0" "$@"
 fi
 
 set -euo pipefail
 
 # ---- config ---------------------------------------------------------------
-SIZE_GB=32
-MOUNTPOINT="$(pwd)/RamDisk"
+SIZE_GB=${SIZE_GB:-32}
 ARCHIVE_SUBDIR="testFiles"
-SOURCE="$HOME/$ARCHIVE_SUBDIR"
+SOURCE=${SOURCE:-"$HOME/$ARCHIVE_SUBDIR"}
+MOUNTPOINT=${MOUNTPOINT:-$(mktemp -d)}
 GOXA_OUTPUT="$MOUNTPOINT/${ARCHIVE_SUBDIR}.goxa"
 TAR_OUTPUT="$MOUNTPOINT/${ARCHIVE_SUBDIR}.tar.gz"
 MOUNTED=0
+
+# timing helper
+time_cmd() {
+    local _tmp
+    _tmp=$(mktemp)
+    /usr/bin/time -f "%e %U %S" -o "$_tmp" "$@" >/dev/null
+    read -r _real _user _sys < "$_tmp"
+    rm -f "$_tmp"
+    echo "$_real" "$(awk -v u="$_user" -v s="$_sys" 'BEGIN{print u + s}')"
+}
 
 # ---- cleanup function -----------------------------------------------------
 cleanup_on_exit() {
@@ -50,21 +59,11 @@ cp -rv "$SOURCE/." "$MOUNTPOINT/$ARCHIVE_SUBDIR"
 # ---- goxa archive + timing ------------------------------------------------
 echo "📆 Archiving with goXA to $GOXA_OUTPUT..."
 go build
-GOXA_TIME="$(mktemp)"
-/usr/bin/time -f "%e %U %S" -o "$GOXA_TIME" \
-  ./goXA ci -arc="$GOXA_OUTPUT" "$MOUNTPOINT/$ARCHIVE_SUBDIR"
-read -r goxa_real goxa_user goxa_sys < "$GOXA_TIME"
-goxa_cpu=$(awk "BEGIN {print $goxa_user + $goxa_sys}")
-rm -f "$GOXA_TIME"
+read -r goxa_real goxa_cpu < <(time_cmd ./goXA ci -arc="$GOXA_OUTPUT" "$MOUNTPOINT/$ARCHIVE_SUBDIR")
 
 # ---- tar archive + timing -------------------------------------------------
 echo "📆 Creating tar.gz archive to $TAR_OUTPUT..."
-TAR_TIME="$(mktemp)"
-/usr/bin/time -f "%e %U %S" -o "$TAR_TIME" \
-  tar -czf "$TAR_OUTPUT" -C "$MOUNTPOINT" "$ARCHIVE_SUBDIR"
-read -r tar_real tar_user tar_sys < "$TAR_TIME"
-tar_cpu=$(awk "BEGIN {print $tar_user + $tar_sys}")
-rm -f "$TAR_TIME"
+read -r tar_real tar_cpu < <(time_cmd tar -czf "$TAR_OUTPUT" -C "$MOUNTPOINT" "$ARCHIVE_SUBDIR")
 
 # ---- decompression test --------------------------------------------------
 echo "\n📂 Benchmarking decompression..."
@@ -74,87 +73,21 @@ mkdir -p "$GOXA_EXTRACT" "$TAR_EXTRACT"
 
 # goXA extract
 echo "📂 Extracting with goXA to $GOXA_EXTRACT..."
-GOXA_X_TIME="$(mktemp)"
-/usr/bin/time -f "%e %U %S" -o "$GOXA_X_TIME" \
-  ./goXA xu -arc="$GOXA_OUTPUT" "$GOXA_EXTRACT"
-read -r goxa_x_real goxa_x_user goxa_x_sys < "$GOXA_X_TIME"
-goxa_x_cpu=$(awk "BEGIN {print $goxa_x_user + $goxa_x_sys}")
-rm -f "$GOXA_X_TIME"
+read -r goxa_x_real goxa_x_cpu < <(time_cmd ./goXA xu -arc="$GOXA_OUTPUT" "$GOXA_EXTRACT")
 
 # tar extract
 echo "📂 Extracting with tar to $TAR_EXTRACT..."
-TAR_X_TIME="$(mktemp)"
-/usr/bin/time -f "%e %U %S" -o "$TAR_X_TIME" \
-  tar -xzf "$TAR_OUTPUT" -C "$TAR_EXTRACT"
-read -r tar_x_real tar_x_user tar_x_sys < "$TAR_X_TIME"
-tar_x_cpu=$(awk "BEGIN {print $tar_x_user + $tar_x_sys}")
-rm -f "$TAR_X_TIME"
+read -r tar_x_real tar_x_cpu < <(time_cmd tar -xzf "$TAR_OUTPUT" -C "$TAR_EXTRACT")
 
 # ---- size summary ---------------------------------------------------------
 echo "\n✅ Archives created:"
 ls -lh "$GOXA_OUTPUT" "$TAR_OUTPUT"
 
-# ---- compression performance ---------------------------------------------
-echo "\n📊 Comparing compression performance..."
-if (( $(awk "BEGIN {exit !($goxa_cpu < $tar_cpu)}") )); then
-    cpu_winner="goXA"
-    cpu_loser="tar"
-    cpu_savings=$(awk "BEGIN {print ($tar_cpu - $goxa_cpu) / $tar_cpu * 100}")
-else
-    cpu_winner="tar"
-    cpu_loser="goXA"
-    cpu_savings=$(awk "BEGIN {print ($goxa_cpu - $tar_cpu) / $goxa_cpu * 100}")
-fi
+# ---- results --------------------------------------------------------------
+echo "\n📊 Compression Results:"
+printf 'goXA: real=%ss, cpu=%ss\n' "$goxa_real" "$goxa_cpu"
+printf 'tar:  real=%ss, cpu=%ss\n' "$tar_real" "$tar_cpu"
 
-goxa_eff=$(awk "BEGIN {print $goxa_cpu / $goxa_real}")
-tar_eff=$(awk "BEGIN {print $tar_cpu / $tar_real}")
-
-is_goxa_faster=$(awk "BEGIN {print ($goxa_real < $tar_real) ? 1 : 0}")
-if [[ "$is_goxa_faster" == "1" ]]; then
-    faster="goXA"
-    wall_speedup=$(awk "BEGIN {print $tar_real / $goxa_real}")
-    wall_diff_pct=$(awk "BEGIN {print (1 - $goxa_real / $tar_real) * 100}")
-    cpu_speedup=$(awk "BEGIN {print $tar_cpu / $goxa_cpu}")
-    cpu_diff_pct=$(awk "BEGIN {print (1 - $goxa_cpu / $tar_cpu) * 100}")
-else
-    faster="tar"
-    wall_speedup=$(awk "BEGIN {print $goxa_real / $tar_real}")
-    wall_diff_pct=$(awk "BEGIN {print (1 - $tar_real / $goxa_real) * 100}")
-    cpu_speedup=$(awk "BEGIN {print $goxa_cpu / $tar_cpu}")
-    cpu_diff_pct=$(awk "BEGIN {print (1 - $tar_cpu / $goxa_cpu) * 100}")
-fi
-
-echo "📆 Compression Results:"
-echo "📆 goXA: real=${goxa_real}s, cpu=${goxa_cpu}s"
-echo "📆 tar:  real=${tar_real}s, cpu=${tar_cpu}s"
-
-# ---- decompression performance -------------------------------------------
-echo "\n📊 Comparing decompression performance..."
-if (( $(awk "BEGIN {exit !($goxa_x_cpu < $tar_x_cpu)}") )); then
-    x_cpu_winner="goXA"
-    x_cpu_loser="tar"
-    x_cpu_savings=$(awk "BEGIN {print ($tar_x_cpu - $goxa_x_cpu) / $tar_x_cpu * 100}")
-else
-    x_cpu_winner="tar"
-    x_cpu_loser="goXA"
-    x_cpu_savings=$(awk "BEGIN {print ($goxa_x_cpu - $tar_x_cpu) / $goxa_x_cpu * 100}")
-fi
-
-x_is_goxa_faster=$(awk "BEGIN {print ($goxa_x_real < $tar_x_real) ? 1 : 0}")
-if [[ "$x_is_goxa_faster" == "1" ]]; then
-    x_faster="goXA"
-    x_wall_speedup=$(awk "BEGIN {print $tar_x_real / $goxa_x_real}")
-    x_wall_diff_pct=$(awk "BEGIN {print (1 - $goxa_x_real / $tar_x_real) * 100}")
-    x_cpu_speedup=$(awk "BEGIN {print $tar_x_cpu / $goxa_x_cpu}")
-    x_cpu_diff_pct=$(awk "BEGIN {print (1 - $goxa_x_cpu / $tar_x_cpu) * 100}")
-else
-    x_faster="tar"
-    x_wall_speedup=$(awk "BEGIN {print $goxa_x_real / $tar_x_real}")
-    x_wall_diff_pct=$(awk "BEGIN {print (1 - $tar_x_real / $goxa_x_real) * 100}")
-    x_cpu_speedup=$(awk "BEGIN {print $goxa_x_cpu / $tar_x_cpu}")
-    x_cpu_diff_pct=$(awk "BEGIN {print (1 - $tar_x_cpu / $goxa_x_cpu) * 100}")
-fi
-
-echo "📆 Decompression Results:"
-echo "📆 goXA: real=${goxa_x_real}s, cpu=${goxa_x_cpu}s"
-echo "📆 tar:  real=${tar_x_real}s, cpu=${tar_x_cpu}s"
+echo "\n📊 Decompression Results:"
+printf 'goXA: real=%ss, cpu=%ss\n' "$goxa_x_real" "$goxa_x_cpu"
+printf 'tar:  real=%ss, cpu=%ss\n' "$tar_x_real" "$tar_x_cpu"


### PR DESCRIPTION
## Summary
- simplify `benchmark.sh`
- add helper for timing and use temporary ramdisk
- print condensed results

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684a0d23184c832a8610130af9f5a2ba