### PR TITLE
Fix test script hanging

### DIFF
--- a/test-goxa.sh
+++ b/test-goxa.sh
@@ -121,7 +121,7 @@ echo "tar format tests ok"
 "$GOXA" l -interactive=false -progress=false -arc "$TMPDIR/test.goxa" >"$TMPDIR/list.txt"
 grep -q "file_1.bin" "$TMPDIR/list.txt"
 
-"$GOXA" j -interactive=false -progress=false -arc "$TMPDIR/test.goxa" | sed -n '/^{/,$p' >"$TMPDIR/list.json"
+"$GOXA" j -interactive=false -progress=false -stdout -arc "$TMPDIR/test.goxa" >"$TMPDIR/list.json"
 python3 -m json.tool "$TMPDIR/list.json" >/dev/null
 grep -q "file_1.bin" "$TMPDIR/list.json"
 

--- a/test-goxa.sh
+++ b/test-goxa.sh
@@ -71,57 +71,57 @@ validate() {
 }
 
 # goxa archive with compression
-"$GOXA" cpmsi -progress=false -arc "$TMPDIR/test.goxa" "$SRC"
-"$GOXA" xpmsi -progress=false -arc "$TMPDIR/test.goxa" "$OUT/comp"
+"$GOXA" cpmsi -interactive=false -progress=false -arc "$TMPDIR/test.goxa" "$SRC"
+"$GOXA" xpmsi -interactive=false -progress=false -arc "$TMPDIR/test.goxa" "$OUT/comp"
 validate "$SRC" "$OUT/comp/$ORIG_NAME" "compressed"
 
 echo "compressed archive ok"
 
 # no compression
-"$GOXA" cpmsin -progress=false -arc "$TMPDIR/test_nocomp.goxa" "$SRC"
-"$GOXA" xpmsi -progress=false -arc "$TMPDIR/test_nocomp.goxa" "$OUT/nocomp"
+"$GOXA" cpmsin -interactive=false -progress=false -arc "$TMPDIR/test_nocomp.goxa" "$SRC"
+"$GOXA" xpmsi -interactive=false -progress=false -arc "$TMPDIR/test_nocomp.goxa" "$OUT/nocomp"
 validate "$SRC" "$OUT/nocomp/$ORIG_NAME" "nocomp"
 
 echo "no compression archive ok"
 
 # Base64 and Base32 encoding
-"$GOXA" cpmsi -progress=false -arc "$TMPDIR/test_b64.goxa.b64" "$SRC"
-"$GOXA" xpmsi -progress=false -arc "$TMPDIR/test_b64.goxa.b64" "$OUT/b64"
+"$GOXA" cpmsi -interactive=false -progress=false -arc "$TMPDIR/test_b64.goxa.b64" "$SRC"
+"$GOXA" xpmsi -interactive=false -progress=false -arc "$TMPDIR/test_b64.goxa.b64" "$OUT/b64"
 validate "$SRC" "$OUT/b64/$ORIG_NAME" "base64"
 
-"$GOXA" cpmsi -progress=false -arc "$TMPDIR/test_b32.goxa.b32" "$SRC"
-"$GOXA" xpmsi -progress=false -arc "$TMPDIR/test_b32.goxa.b32" "$OUT/b32"
+"$GOXA" cpmsi -interactive=false -progress=false -arc "$TMPDIR/test_b32.goxa.b32" "$SRC"
+"$GOXA" xpmsi -interactive=false -progress=false -arc "$TMPDIR/test_b32.goxa.b32" "$OUT/b32"
 validate "$SRC" "$OUT/b32/$ORIG_NAME" "base32"
 
 echo "encoding tests ok"
 
 # FEC encoding with high redundancy
-"$GOXA" cpmsi -progress=false -fec-level=high -arc "$TMPDIR/test_fec.goxaf" "$SRC"
-"$GOXA" xpmsi -progress=false -arc "$TMPDIR/test_fec.goxaf" "$OUT/fec"
+"$GOXA" cpmsi -interactive=false -progress=false -fec-level=high -arc "$TMPDIR/test_fec.goxaf" "$SRC"
+"$GOXA" xpmsi -interactive=false -progress=false -arc "$TMPDIR/test_fec.goxaf" "$OUT/fec"
 validate "$SRC" "$OUT/fec/$ORIG_NAME" "fec"
 
 echo "fec archive ok"
 
 # Tar formats
-"$GOXA" cpmsi -progress=false -arc "$TMPDIR/test.tar.gz" "$SRC"
-"$GOXA" xpmsi -progress=false -arc "$TMPDIR/test.tar.gz" "$OUT/targz"
+"$GOXA" cpmsi -interactive=false -progress=false -arc "$TMPDIR/test.tar.gz" "$SRC"
+"$GOXA" xpmsi -interactive=false -progress=false -arc "$TMPDIR/test.tar.gz" "$OUT/targz"
 validate "$SRC" "$OUT/targz/$ORIG_NAME" "targz"
 
-"$GOXA" cpmsi -progress=false -arc "$TMPDIR/test.tar.xz" "$SRC"
-"$GOXA" xpmsi -progress=false -arc "$TMPDIR/test.tar.xz" "$OUT/tarxz"
+"$GOXA" cpmsi -interactive=false -progress=false -arc "$TMPDIR/test.tar.xz" "$SRC"
+"$GOXA" xpmsi -interactive=false -progress=false -arc "$TMPDIR/test.tar.xz" "$OUT/tarxz"
 validate "$SRC" "$OUT/tarxz/$ORIG_NAME" "tarxz"
 
-"$GOXA" cpmsin -progress=false -arc "$TMPDIR/test.tar" "$SRC"
-"$GOXA" xpmsi -progress=false -arc "$TMPDIR/test.tar" "$OUT/tar"
+"$GOXA" cpmsin -interactive=false -progress=false -arc "$TMPDIR/test.tar" "$SRC"
+"$GOXA" xpmsi -interactive=false -progress=false -arc "$TMPDIR/test.tar" "$OUT/tar"
 validate "$SRC" "$OUT/tar/$ORIG_NAME" "tar"
 
 echo "tar format tests ok"
 
 # Listing and JSON output
-"$GOXA" l -progress=false -arc "$TMPDIR/test.goxa" >"$TMPDIR/list.txt"
+"$GOXA" l -interactive=false -progress=false -arc "$TMPDIR/test.goxa" >"$TMPDIR/list.txt"
 grep -q "file_1.bin" "$TMPDIR/list.txt"
 
-"$GOXA" j -progress=false -arc "$TMPDIR/test.goxa" >"$TMPDIR/list.json"
+"$GOXA" j -interactive=false -progress=false -arc "$TMPDIR/test.goxa" | sed -n '/^{/,$p' >"$TMPDIR/list.json"
 python3 -m json.tool "$TMPDIR/list.json" >/dev/null
 grep -q "file_1.bin" "$TMPDIR/list.json"
 
@@ -129,7 +129,7 @@ echo "listing commands ok"
 
 # Extract specific file
 mkdir -p "$OUT/partial"
-"$GOXA" xpmsi -progress=false -arc "$TMPDIR/test.goxa" -files "$ORIG_NAME/file_1.bin" "$OUT/partial"
+"$GOXA" xpmsi -interactive=false -progress=false -arc "$TMPDIR/test.goxa" -files "$ORIG_NAME/file_1.bin" "$OUT/partial"
 if [ ! -f "$OUT/partial/$ORIG_NAME/file_1.bin" ]; then
   echo "selected file missing" >&2
   exit 1
@@ -142,8 +142,8 @@ fi
 echo "partial extraction ok"
 
 # Stdout archive
-"$GOXA" cpmsi -progress=false -stdout -arc dummy "$SRC" >"$TMPDIR/stdout.goxa"
-"$GOXA" xpmsi -progress=false -arc "$TMPDIR/stdout.goxa" "$OUT/stdout"
+"$GOXA" cpmsi -interactive=false -progress=false -stdout -arc dummy "$SRC" >"$TMPDIR/stdout.goxa"
+"$GOXA" xpmsi -interactive=false -progress=false -arc "$TMPDIR/stdout.goxa" "$OUT/stdout"
 validate "$SRC" "$OUT/stdout/$ORIG_NAME" "stdout"
 
 echo "stdout handling ok"


### PR DESCRIPTION
## Summary
- prevent prompts in `test-goxa.sh` by disabling interactive mode for all goxa invocations
- clean JSON listing output before validating

## Testing
- `TEST_BYTES=$((1*1024*1024)) bash -x test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a27e2acf4832ab3932a2d9fc84e77