### PR TITLE
Add quiet mode for stdout and JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ goxa MODE[flags] [options] -arc FILE [paths...]
 - `c` – create an archive
 - `l` – list contents
 - `j` – output JSON list
+- Selecting `-stdout` or using `j` suppresses progress and informational output.
 - `x` – extract files
 
 Single letter flags follow the mode, e.g. `goxa cpms -arc=out.goxa dir/`.
@@ -91,7 +92,7 @@ flags you did not specify. It will ask which missing flags to enable, or
 | Option | Description |
 |--------|-------------|
 | `-arc` | archive file name |
-| `-stdout` | write archive to stdout |
+| `-stdout` | write archive to stdout (suppresses other output) |
 | `-files` | comma-separated list to extract |
 | `-progress=false` | disable progress display |
 | `-interactive=false` | disable prompts for archive flags |

--- a/cli_e2e_test.go
+++ b/cli_e2e_test.go
@@ -13,6 +13,7 @@ func resetGlobals() {
 	doForce = false
 	toStdOut = false
 	progress = false
+	quietMode = false
 	features = 0
 	compression = ""
 	extractList = nil

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 var (
 	archivePath                              string
 	verboseMode, doForce, toStdOut, progress bool
+	quietMode                                bool
 	interactiveMode                          bool = true
 	features                                 BitFlags
 	useArchiveFlags                          bool

--- a/goxa.1
+++ b/goxa.1
@@ -27,7 +27,7 @@ Create a new archive.
 List archive contents.
 .TP
 .B j
-Output a JSON listing of the archive.
+Output a JSON listing of the archive. This also suppresses progress and other output.
 .TP
 .B x
 Extract files from an archive.
@@ -73,7 +73,7 @@ Longer options use the usual \fB-flag=value\fP form.
 Archive file name.
 .TP
 .B -stdout
-Write archive data to standard output.
+Write archive data to standard output and suppress other output.
 .TP
 .BI -files " LIST"
 Comma separated list of files/directories to extract.

--- a/main.go
+++ b/main.go
@@ -86,6 +86,10 @@ func main() {
 	var showVer bool
 	flagSet.BoolVar(&showVer, "version", false, "print version and exit")
 	flagSet.Parse(os.Args[2:])
+	quietMode = toStdOut || cmdLetter == 'j'
+	if quietMode {
+		progress = false
+	}
 	switch fecLevel {
 	case "low":
 		fecDataShards, fecParityShards = 10, 3

--- a/progress.go
+++ b/progress.go
@@ -45,7 +45,7 @@ type progressData struct {
 func progressTicker(p *progressData) (*progressData, chan struct{}, chan struct{}) {
 	done := make(chan struct{})
 	finished := make(chan struct{})
-	if !progress {
+	if !progress || quietMode {
 		close(finished)
 		return p, done, finished
 	}
@@ -73,7 +73,7 @@ func progressTicker(p *progressData) (*progressData, chan struct{}, chan struct{
 }
 
 func printProgress(p *progressData) {
-	if !progress {
+	if !progress || quietMode {
 		return
 	}
 	now := time.Now()

--- a/util.go
+++ b/util.go
@@ -234,7 +234,7 @@ func detectFormatFromHeader(name string) (string, bool, bool) {
 }
 
 func doLog(verbose bool, format string, args ...interface{}) {
-	if toStdOut || (!verboseMode && verbose) {
+	if quietMode || toStdOut || (!verboseMode && verbose) {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- support quiet mode when writing to stdout or printing JSON
- document new behavior in README and man page
- adjust progress logger and unit tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684a2b344964832aba93f2de54ca6fcf