### PR TITLE
Add checksum algorithm option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ flags you did not specify. It will ask which missing flags to enable, or
 | `-interactive=false` | disable prompts for archive flags |
 | `-comp` | compression algorithm |
 | `-speed` | compression speed level |
+| `-sum` | checksum algorithm (crc32, crc16, xxhash, sha256, blake3) |
 | `-format` | force `goxa` or `tar` format |
 | `-retries` | retries when a file changes during read |
 | `-retrydelay` | seconds to wait between retries |


### PR DESCRIPTION
## Summary
- add `-sum` flag to choose checksum algorithm
- update usage text and README for new flag

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684a2d0b1b28832ab8ea74a17604e6ab