### PR TITLE
Switch module name to lowercase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module goXA
+module goxa
 
 go 1.24.1
 


### PR DESCRIPTION
## Summary
- use a lowercase module name in `go.mod` so the built binary is `goxa`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684a2edc50e8832a89e3ca10156ee9a7