### PR TITLE
Switch binary name to goxa

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -57,9 +57,9 @@ mkdir -p "$MOUNTPOINT/$ARCHIVE_SUBDIR"
 cp -rv "$SOURCE/." "$MOUNTPOINT/$ARCHIVE_SUBDIR"
 
 # ---- goxa archive + timing ------------------------------------------------
-echo "📆 Archiving with goXA to $GOXA_OUTPUT..."
+echo "📆 Archiving with goxa to $GOXA_OUTPUT..."
 go build
-read -r goxa_real goxa_cpu < <(time_cmd ./goXA ci -arc="$GOXA_OUTPUT" "$MOUNTPOINT/$ARCHIVE_SUBDIR")
+read -r goxa_real goxa_cpu < <(time_cmd ./goxa ci -arc="$GOXA_OUTPUT" "$MOUNTPOINT/$ARCHIVE_SUBDIR")
 
 # ---- tar archive + timing -------------------------------------------------
 echo "📆 Creating tar.gz archive to $TAR_OUTPUT..."
@@ -71,9 +71,9 @@ GOXA_EXTRACT="$MOUNTPOINT/extracted_goxa"
 TAR_EXTRACT="$MOUNTPOINT/extracted_tar"
 mkdir -p "$GOXA_EXTRACT" "$TAR_EXTRACT"
 
-# goXA extract
-echo "📂 Extracting with goXA to $GOXA_EXTRACT..."
-read -r goxa_x_real goxa_x_cpu < <(time_cmd ./goXA xu -arc="$GOXA_OUTPUT" "$GOXA_EXTRACT")
+# goxa extract
+echo "📂 Extracting with goxa to $GOXA_EXTRACT..."
+read -r goxa_x_real goxa_x_cpu < <(time_cmd ./goxa xu -arc="$GOXA_OUTPUT" "$GOXA_EXTRACT")
 
 # tar extract
 echo "📂 Extracting with tar to $TAR_EXTRACT..."
@@ -85,9 +85,9 @@ ls -lh "$GOXA_OUTPUT" "$TAR_OUTPUT"
 
 # ---- results --------------------------------------------------------------
 echo "\n📊 Compression Results:"
-printf 'goXA: real=%ss, cpu=%ss\n' "$goxa_real" "$goxa_cpu"
+printf 'goxa: real=%ss, cpu=%ss\n' "$goxa_real" "$goxa_cpu"
 printf 'tar:  real=%ss, cpu=%ss\n' "$tar_real" "$tar_cpu"
 
 echo "\n📊 Decompression Results:"
-printf 'goXA: real=%ss, cpu=%ss\n' "$goxa_x_real" "$goxa_x_cpu"
+printf 'goxa: real=%ss, cpu=%ss\n' "$goxa_x_real" "$goxa_x_cpu"
 printf 'tar:  real=%ss, cpu=%ss\n' "$tar_x_real" "$tar_x_cpu"

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 		fs.BoolVar(&showHelp, "h", false, "show help")
 		fs.Parse(os.Args[1:])
 		if showVer {
-			fmt.Println("goXA v" + appVersion)
+			fmt.Println("goxa v" + appVersion)
 			return
 		}
 		showUsage()
@@ -106,7 +106,7 @@ func main() {
 		log.Fatalf("invalid fec-level: %s", fecLevel)
 	}
 	if showVer {
-		fmt.Println("goXA v" + appVersion)
+		fmt.Println("goxa v" + appVersion)
 		return
 	}
 
@@ -303,7 +303,7 @@ func main() {
 }
 
 func showUsage() {
-	fmt.Println("GoXA - Go eXpress Archive")
+	fmt.Println("goxa - Go eXpress Archive")
 	fmt.Println()
 	fmt.Println("Usage:")
 	fmt.Println("  goxa MODE[flags] [options] -arc FILE [paths...]")

--- a/test-goxa.sh
+++ b/test-goxa.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Extensive end-to-end testing of goXA covering many CLI combinations.
+# Extensive end-to-end testing of goxa covering many CLI combinations.
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 


### PR DESCRIPTION
## Summary
- print `goxa` instead of `goXA` when showing version/help
- adjust benchmark and e2e script messages to use `goxa`

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a2ff8bde8832a99baf4b8c343e94f