### PR TITLE
Improve docs for safe defaults

### DIFF
--- a/PURPOSE.md
+++ b/PURPOSE.md
@@ -1,41 +1,22 @@
 # Purpose and Design Rationale
 
-GoXA aims to be a modern replacement for classic archivers such as `tar`.
-The defaults are intentionally safe and predictable so that new users can
-create and extract archives without fear of damaging their system or losing
-files.
+GoXA aims to be a modern replacement for classic archivers such as `tar`. The defaults are intentionally safe and predictable so that new users can create and extract archives without fear of damaging their system or losing files.
 
 ## Default Safety
 
-* **Checksums enabled** – every file is protected by a Blake3 checksum to
-  detect corruption early while keeping speed high.
-* **No dotfiles** – hidden files are skipped unless the `i` flag is used.
-  This prevents accidentally archiving temporary editor artifacts or
-  configuration secrets.
-* **Relative paths only** – without `a`, paths are stored relative so
-  extraction cannot write outside the current directory tree.
-* **No overwrite by default** – files are never replaced unless you pass `f`.
-  Mistakes are caught instead of silently clobbering data.
-* **Zip bomb detection** – extremely compressed files are refused unless
-  `-bombcheck=false` is set, guarding against denial-of-service archives.
-* **Space check** – before writing or extracting an archive GoXA verifies there
-  is enough free space so operations do not stop midway.
-* **Interactive prompts** – when an archive was created with flags you did not
-  specify, GoXA asks before enabling them. This makes unexpected behaviour
-  explicit.
-* **Progress bar** – a clear progress display is shown for interactive runs so
-  you know the program is working and can estimate completion time.
-* **`-arc` required** – the archive name is always supplied explicitly which
-  avoids mistakes when scripts are moved between directories.
+* **Checksums enabled** – every file is protected by a Blake3 checksum to detect corruption early while keeping speed high.
+* **No dotfiles** – hidden files are skipped unless the `i` flag is used. This prevents accidentally archiving temporary editor artifacts or configuration secrets.
+* **Relative paths only** – without `a`, paths are stored relative so extraction cannot write outside the current directory tree.
+* **No overwrite by default** – files are never replaced unless you pass `f`. Mistakes are caught instead of silently clobbering data.
+* **Zip bomb detection** – extremely compressed files are refused unless `-bombcheck=false` is set, guarding against denial-of-service archives.
+* **Space check** – before writing or extracting an archive GoXA verifies there is enough free space so operations do not stop midway.
+* **Interactive prompts** – when an archive was created with flags you did not specify, GoXA asks before enabling them. This makes unexpected behaviour explicit.
+* **Progress bar** – a clear progress display is shown for interactive runs so you know the program is working or detect possible issues.
+* **`-arc` required** – the archive name is always supplied explicitly which avoids mistakes when scripts are moved between directories.
 
 ## Performance Choices
 
-GoXA writes data in large 512KiB blocks by default
-(see `defaultBlockSize` in `const.go`). A trailer at the end of the file lists
-all block offsets so readers can jump directly to any file. The layout lends
-itself to multi-threaded reading and writing, letting GoXA scale with modern
-hardware.
+GoXA writes data in large 512KiB blocks by default (see `defaultBlockSize` in `const.go`). A trailer at the end of the file lists all block offsets so readers can jump directly to any part of any file. The layout lends itself to multi-threaded reading and writing, letting GoXA scale with modern
+hardware. Older utilities like tar only work with 0.5kb blocks, leading to a lot of overhead. Additionally, goxa uses read and write buffers (default 1MiB) to keep the CPU productive and further reduce overhead.
 
-Together these choices make GoXA safer and faster than traditional tools.
-Checksums catch errors immediately, the block trailer allows random access and
-parallelism, and sensible prompts keep the user in control.
+Together these choices make GoXA safer and faster than traditional tools. Checksums catch errors immediately, the block trailer allows random access and parallelism, and sensible prompts keep the user in control.

--- a/PURPOSE.md
+++ b/PURPOSE.md
@@ -1,0 +1,41 @@
+# Purpose and Design Rationale
+
+GoXA aims to be a modern replacement for classic archivers such as `tar`.
+The defaults are intentionally safe and predictable so that new users can
+create and extract archives without fear of damaging their system or losing
+files.
+
+## Default Safety
+
+* **Checksums enabled** – every file is protected by a Blake3 checksum to
+  detect corruption early while keeping speed high.
+* **No dotfiles** – hidden files are skipped unless the `i` flag is used.
+  This prevents accidentally archiving temporary editor artifacts or
+  configuration secrets.
+* **Relative paths only** – without `a`, paths are stored relative so
+  extraction cannot write outside the current directory tree.
+* **No overwrite by default** – files are never replaced unless you pass `f`.
+  Mistakes are caught instead of silently clobbering data.
+* **Zip bomb detection** – extremely compressed files are refused unless
+  `-bombcheck=false` is set, guarding against denial-of-service archives.
+* **Space check** – before writing or extracting an archive GoXA verifies there
+  is enough free space so operations do not stop midway.
+* **Interactive prompts** – when an archive was created with flags you did not
+  specify, GoXA asks before enabling them. This makes unexpected behaviour
+  explicit.
+* **Progress bar** – a clear progress display is shown for interactive runs so
+  you know the program is working and can estimate completion time.
+* **`-arc` required** – the archive name is always supplied explicitly which
+  avoids mistakes when scripts are moved between directories.
+
+## Performance Choices
+
+GoXA writes data in large 512KiB blocks by default
+(see `defaultBlockSize` in `const.go`). A trailer at the end of the file lists
+all block offsets so readers can jump directly to any file. The layout lends
+itself to multi-threaded reading and writing, letting GoXA scale with modern
+hardware.
+
+Together these choices make GoXA safer and faster than traditional tools.
+Checksums catch errors immediately, the block trailer allows random access and
+parallelism, and sensible prompts keep the user in control.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ A fast, portable archiving utility written in Go.
 - Base32, Base64 and FEC `forward error correcting` encoding when the archive name ends with `.b32`, `.b64` or `.goxaf`
 - Fully documented format: see [FILE-FORMAT.md](FILE-FORMAT.md) and [JSON-LIST-FORMAT.md](JSON-LIST-FORMAT.md)
 
+## Default Behavior
+
+GoXA is conservative by default. Archives only store relative paths and hidden
+files are skipped unless `i` is specified. Checksums use fast but strong Blake3
+hashes. Existing files are never overwritten unless the `f` flag is given. Zip
+bombs and free space are checked automatically. The progress display is enabled
+for all interactive runs and the program prompts when an archive was created
+with extra flags so you can confirm them. You always supply the archive name with
+`-arc` to avoid surprises.
+
+Data is written in large 512KiB blocks for high throughput. Each archive ends
+with a trailer that records the offset of every block so readers can jump
+directly to any file. The block system is designed for future multi-threaded
+readers and writers.
+
 ## Installation
 
 With Go 1.24+ you can install directly:

--- a/README.md
+++ b/README.md
@@ -34,18 +34,10 @@ A fast, portable archiving utility written in Go.
 
 ## Default Behavior
 
-GoXA is conservative by default. Archives only store relative paths and hidden
-files are skipped unless `i` is specified. Checksums use fast but strong Blake3
-hashes. Existing files are never overwritten unless the `f` flag is given. Zip
-bombs and free space are checked automatically. The progress display is enabled
-for all interactive runs and the program prompts when an archive was created
-with extra flags so you can confirm them. You always supply the archive name with
-`-arc` to avoid surprises.
+GoXA is conservative by default. Archives only store relative paths by default and hidden files are skipped unless `i` is specified. Checksums use fast but strong Blake3 hashes. Existing files are never overwritten unless the `f` flag is given. Zip bombs and free space are checked automatically. The
+progress display is enabled for all interactive runs and the program prompts when an archive was created with extra flags so you can confirm them. You always supply the archive name with `-arc` to avoid surprises.
 
-Data is written in large 512KiB blocks for high throughput. Each archive ends
-with a trailer that records the offset of every block so readers can jump
-directly to any file. The block system is designed for future multi-threaded
-readers and writers.
+Data is written in large 512KiB blocks for high throughput. Each archive ends with a trailer that records the offset of every block so readers can jump directly to any part of any file. The block system is designed for future multi-threaded readers and writers.
 
 ## Installation
 
@@ -79,8 +71,7 @@ goxa MODE[flags] [options] -arc FILE [paths...]
 - Selecting `-stdout` or using `j` suppresses progress and informational output.
 - `x` – extract files
 
-Single letter flags follow the mode, e.g. `goxa cpm -arc=out.goxa dir/`.
-Longer options use the usual `-flag=value` form.
+Single letter flags follow the mode, e.g. `goxa cpm -arc=out.goxa dir/`. Longer options use the usual `-flag=value` form.
 
 ### Common Flags
 
@@ -98,10 +89,7 @@ Longer options use the usual `-flag=value` form.
 | `v` | verbose output |
 | `f` | force overwrite / ignore read errors |
 
-When extracting, the program prompts if the archive was created with
-flags you did not specify. It will ask which missing flags to enable, or
-`u` to enable all. Press Enter to continue without them. Use
-`-interactive=false` to skip prompts.
+When extracting, the program prompts if the archive was created with flags you did not specify. It will ask which missing flags to enable, or `u` to enable all. Press Enter to continue without them. Use `-interactive=false` to skip prompts.
 
 ### Options
 
@@ -130,7 +118,8 @@ Progress shows transfer speed and current file. Snappy does not support adjustab
 
 ### Base32 / Base64 / FEC
 
-Appending `.b32` or `.b64` to the archive file encodes the archive in Base32 or Base64. Files ending in `.goxaf` are FEC `error correcting` encoded. FEC archives contain data and parity shards using Reed-Solomon codes; any missing shards up to the parity count can be reconstructed when extracting. For example, with `-fec-data=10 -fec-parity=3` the archive is split into 13 shards. Any 10 shards are enough to fully recover the data. Presets are:
+Appending `.b32` or `.b64` to the archive file encodes the archive in Base32 or Base64. Files ending in `.goxaf` are FEC `error correcting` encoded. FEC archives contain data and parity shards using Reed-Solomon codes; any missing shards up to the parity count can be reconstructed when extracting.
+For example, with `-fec-data=10 -fec-parity=3` the archive is split into 13 shards. Any 10 shards are enough to fully recover the data. Presets are:
 
 ```
 low    -> 10 data / 3 parity

--- a/goxa.1
+++ b/goxa.1
@@ -18,6 +18,15 @@ goxa \- Go eXpress Archive
 .RI "[flags] -arc FILE [destination]"
 .SH DESCRIPTION
 GoXA is a small archiver written in Go. It understands its own \fB.goxa\fP format and standard tar archives. Compression, checksums and most metadata are optional and controlled by flags. Archives can be streamed to stdout and, when the file name ends in \fB.b32\fP or \fB.b64\fP, encoded using Base32 or Base64. Files ending in \fB.goxaf\fP are encoded with forward error correction (FEC).
+.SH DEFAULTS
+Paths are stored relative to avoid accidental overwrites. Hidden files are
+omitted unless \fBi\fP is specified. Blake3 checksums guard every file. Existing
+files are never overwritten unless \fBf\fP is given. The program checks for zip
+bombs and available space and prompts when extra archive flags are detected.
+Progress output is on by default and the archive name must be provided with
+\fB-arc\fP.
+Data blocks default to 512KiB and each archive ends with a trailer listing block
+offsets for fast seeking.
 .SH MODES
 .TP
 .B c


### PR DESCRIPTION
## Summary
- document conservative defaults in README and man page
- create PURPOSE.md describing design rationale

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a50c9e8ec832ab118d3d9db9de617