### PR TITLE
Add PGO training flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ When extracting, the program prompts if the archive was created with flags you d
 | `-spacecheck=false` | disable free space check |
 | `-noflush` | skip final disk flush |
 | `-version` | print program version |
+| `-pgo` | run built-in PGO training |
 | `-fec-data` | number of FEC data shards |
 | `-fec-parity` | number of FEC parity shards |
 | `-fec-level` | redundancy preset: low, medium or high |
@@ -143,6 +144,7 @@ goxa c -arc=backup.goxaf -fec-parity=5 mydir/
 goxa c -arc=mybackup.goxa myStuff/            # create archive
 goxa x -arc=mybackup.goxa                     # extract
 goxa l -arc=mybackup.goxa                     # list contents
+goxa -pgo                                     # generate default.pgo profile
 goxa c -arc=mybackup.tar.gz myStuff/          # create tar.gz
 goxa x -arc=mybackup.tar.xz                   # extract tar.xz
 goxa c -arc=mybackup.goxa -stdout myStuff/ | ssh host "cat > backup.goxa"

--- a/goxa.1
+++ b/goxa.1
@@ -123,6 +123,9 @@ Skip final disk flush.
 .B -version
 Print program version and exit.
 .TP
+.B -pgo
+Run built-in compression/decompression test and write \fBdefault.pgo\fP.
+.TP
 .BI -fec-data " NUM"
 Number of FEC data shards (default 10).
 .TP
@@ -151,6 +154,7 @@ Tar archive compressed with xz.
 .SH EXAMPLES
 .nf
 goxa -version
+goxa -pgo
 goxa c -arc=backup.goxa dir/
 goxa x -arc=backup.goxa
 goxa c -arc=backup.tar.gz dir/

--- a/main.go
+++ b/main.go
@@ -38,12 +38,18 @@ func main() {
 		fs := flag.NewFlagSet("goxa", flag.ExitOnError)
 		var showVer bool
 		var showHelp bool
+		var pgo bool
 		fs.BoolVar(&showVer, "version", false, "print version and exit")
 		fs.BoolVar(&showHelp, "help", false, "show help")
 		fs.BoolVar(&showHelp, "h", false, "show help")
+		fs.BoolVar(&pgo, "pgo", false, "run PGO training and exit")
 		fs.Parse(os.Args[1:])
 		if showVer {
 			fmt.Println("goxa v" + appVersion)
+			return
+		}
+		if pgo {
+			runPGOTraining()
 			return
 		}
 		showUsage()
@@ -343,6 +349,7 @@ func showUsage() {
 	fmt.Println("  -spacecheck=false disable free space check")
 	fmt.Println("  -noflush        skip final disk flush")
 	fmt.Println("  -version        print program version")
+	fmt.Println("  -pgo            run built-in PGO training")
 	fmt.Println("  -fec-data N     number of FEC data shards (default 10)")
 	fmt.Println("  -fec-parity N   number of FEC parity shards (default 3)")
 	fmt.Println("  -fec-level L    FEC redundancy preset (low, medium, high)")
@@ -357,6 +364,7 @@ func showUsage() {
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  goxa -version                                 # print version")
+	fmt.Println("  goxa -pgo                                     # generate default.pgo")
 	fmt.Println("  goxa c -arc=backup.goxa dir/                  # create archive")
 	fmt.Println("  goxa x -arc=backup.goxa                       # extract to folder")
 	fmt.Println("  goxa c -arc=backup.tar.gz dir/                # create tar.gz")

--- a/pgo.go
+++ b/pgo.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"runtime/pprof"
+)
+
+// runPGOTraining performs a simple compression and decompression
+// using default settings and writes a CPU profile to default.pgo.
+func runPGOTraining() {
+	fmt.Println("Generating default.pgo profile...")
+	f, err := os.Create("default.pgo")
+	if err != nil {
+		log.Fatalf("pgo file: %v", err)
+	}
+	defer f.Close()
+	if err := pprof.StartCPUProfile(f); err != nil {
+		log.Fatalf("pgo start: %v", err)
+	}
+	defer pprof.StopCPUProfile()
+
+	data := make([]byte, 5*1024*1024)
+	if _, err := rand.Read(data); err != nil {
+		log.Fatalf("rand: %v", err)
+	}
+
+	var buf bytes.Buffer
+	zw := compressor(&buf)
+	if _, err := zw.Write(data); err != nil {
+		log.Fatalf("compress: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		log.Fatalf("compress close: %v", err)
+	}
+
+	zr, err := decompressor(bytes.NewReader(buf.Bytes()), compType)
+	if err != nil {
+		log.Fatalf("decompress: %v", err)
+	}
+	if _, err := io.Copy(io.Discard, zr); err != nil {
+		log.Fatalf("decompress copy: %v", err)
+	}
+	zr.Close()
+
+	fmt.Println("default.pgo written")
+}


### PR DESCRIPTION
## Summary
- add `-pgo` option and runPGOTraining function
- document new flag in README, man page, and CLI help

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a61bda0f0832aa1b221c61cd4491e