### PR TITLE
Refactor main into helper functions

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,19 +14,7 @@ import (
 const makeProfile = false
 
 func main() {
-
-	if makeProfile {
-		f, err := os.Create("perf.pprof")
-		if err != nil {
-			log.Fatalf("could not create CPU profile: %v", err)
-		}
-		defer f.Close()
-
-		if err := pprof.StartCPUProfile(f); err != nil {
-			log.Fatalf("could not start CPU profile: %v", err)
-		}
-		defer pprof.StopCPUProfile()
-	}
+	defer startProfile()()
 
 	if len(os.Args) < 2 {
 		showUsage()
@@ -35,279 +23,44 @@ func main() {
 	}
 
 	if strings.HasPrefix(os.Args[1], "-") {
-		fs := flag.NewFlagSet("goxa", flag.ExitOnError)
-		var showVer bool
-		var showHelp bool
-		var pgo bool
-		fs.BoolVar(&showVer, "version", false, "print version and exit")
-		fs.BoolVar(&showHelp, "help", false, "show help")
-		fs.BoolVar(&showHelp, "h", false, "show help")
-		fs.BoolVar(&pgo, "pgo", false, "run PGO training and exit")
-		fs.Parse(os.Args[1:])
-		if showVer {
-			fmt.Println("goxa v" + appVersion)
+		if handleTopLevel(os.Args[1:]) {
 			return
 		}
-		if pgo {
-			runPGOTraining()
-			return
-		}
+	}
+
+	cmdLetter, opts := parseCommand(os.Args[1])
+	if !strings.ContainsRune("cljx", rune(cmdLetter)) {
 		showUsage()
+		fmt.Printf("\nError: Unknown mode: %s\n", os.Args[1])
 		return
 	}
 
-	cmd := strings.ToLower(os.Args[1])
-	cmdLetter := cmd[0]
-	if !strings.ContainsRune("cljx", rune(cmdLetter)) {
-		showUsage()
-		fmt.Printf("\nError: Unknown mode: %s\n", cmd)
-		return
-	}
-	opts := ""
-	if len(cmd) > 1 {
-		opts = cmd[1:]
-	}
-	flagSet := flag.NewFlagSet("goxa", flag.ExitOnError)
-	var sel string
-	var format string
-	flagSet.StringVar(&archivePath, "arc", defaultArchiveName, "archive file name (extension not required)")
-	flagSet.BoolVar(&toStdOut, "stdout", false, "output archive data to stdout")
-	flagSet.BoolVar(&progress, "progress", true, "show progress bar")
-	flagSet.BoolVar(&interactiveMode, "interactive", true, "prompt when archive uses extra flags")
-	var speedOpt string
-	var sumOpt string
-	flagSet.StringVar(&compression, "comp", "zstd", "compression: gzip|zstd|lz4|s2|snappy|brotli|xz|none")
-	flagSet.StringVar(&speedOpt, "speed", "fastest", "compression speed: fastest|default|better|best")
-	flagSet.StringVar(&sumOpt, "sum", "blake3", "checksum: crc32|crc16|xxhash|sha256|blake3")
-	flagSet.StringVar(&format, "format", "goxa", "archive format: tar|goxa")
-	flagSet.StringVar(&sel, "files", "", "comma-separated list of files and directories to extract")
-	var fecData int
-	var fecParity int
-	var fecLevel string
-	flagSet.IntVar(&fecData, "fec-data", fecDataShards, "FEC data shards")
-	flagSet.IntVar(&fecParity, "fec-parity", fecParityShards, "FEC parity shards")
-	flagSet.StringVar(&fecLevel, "fec-level", "", "FEC redundancy preset: low|medium|high")
-	flagSet.IntVar(&fileRetries, "retries", 3, "retries when file changes during read (0=never give up)")
-	flagSet.IntVar(&fileRetryDelay, "retrydelay", 5, "delay between retries in seconds")
-	flagSet.BoolVar(&failOnChange, "failonchange", false, "treat file change after retries as fatal")
-	flagSet.BoolVar(&bombCheck, "bombcheck", true, "detect extremely compressed files")
-	flagSet.BoolVar(&spaceCheck, "spacecheck", true, "verify free disk space before operations")
-	flagSet.BoolVar(&noFlush, "noflush", false, "skip final disk flush")
-	var showVer bool
-	flagSet.BoolVar(&showVer, "version", false, "print version and exit")
+	flagSet, mflags := initFlags()
 	flagSet.Parse(os.Args[2:])
+
 	quietMode = toStdOut || cmdLetter == 'j'
 	if quietMode {
 		progress = false
 	}
-	switch fecLevel {
-	case "low":
-		fecDataShards, fecParityShards = 10, 3
-	case "medium":
-		fecDataShards, fecParityShards = 8, 4
-	case "high":
-		fecDataShards, fecParityShards = 5, 5
-	case "":
-		fecDataShards = fecData
-		fecParityShards = fecParity
-	default:
-		log.Fatalf("invalid fec-level: %s", fecLevel)
-	}
-	if showVer {
+
+	configureFEC(mflags)
+	if mflags.showVer {
 		fmt.Println("goxa v" + appVersion)
 		return
 	}
 
-	detFmt, noComp := detectFormatFromExt(archivePath)
-	if detFmt != "" {
-		format = detFmt
-		if detFmt == "tar" {
-			if noComp {
-				features.Set(fNoCompress)
-			} else {
-				features.Clear(fNoCompress)
-			}
-		}
-	}
+	mflags.format = detectArchiveFormat(cmdLetter, mflags.format)
+	buildExtractList(mflags.sel)
 
-	if cmdLetter != 'c' {
-		if fFmt, fNoComp, ok := detectFormatFromHeader(archivePath); ok {
-			format = fFmt
-			if fFmt == "tar" {
-				if fNoComp {
-					features.Set(fNoCompress)
-				} else {
-					features.Clear(fNoCompress)
-				}
-			}
-		}
-	}
+	applyModeOptions(opts)
 
-	if sel != "" {
-		parts := strings.Split(sel, ",")
-		for _, p := range parts {
-			p = strings.TrimSpace(p)
-			if p == "" {
-				continue
-			}
-			extractList = append(extractList, filepath.Clean(p))
-		}
-	}
+	configureCompression(mflags.format)
+	configureSpeed(mflags.speedOpt)
+	configureChecksum(mflags.sumOpt)
 
-	// Clean up archive name will occur after options are parsed
+	ensureArchiveExtension(cmdLetter, mflags.format)
 
-	//Options
-	for _, letter := range opts {
-		switch letter {
-
-		case 'a':
-			features.Set(fAbsolutePaths)
-		case 'p':
-			features.Set(fPermissions)
-		case 'm':
-			features.Set(fModDates)
-		case 's':
-			features.Clear(fChecksums)
-		case 'b':
-			features.Set(fChecksums)
-			features.Set(fBlockChecksums)
-		case 'n':
-			features.Set(fNoCompress)
-		case 'i':
-			features.Set(fIncludeInvis)
-		case 'o':
-			features.Set(fSpecialFiles)
-		case 'u':
-			useArchiveFlags = true
-		case 'v':
-			verboseMode = true
-		case 'f':
-			doForce = true
-		default:
-			continue
-		}
-	}
-
-	switch strings.ToLower(compression) {
-	case "gzip":
-		compType = compGzip
-	case "zstd":
-		compType = compZstd
-	case "lz4":
-		compType = compLZ4
-	case "s2":
-		compType = compS2
-	case "snappy":
-		compType = compSnappy
-	case "brotli":
-		compType = compBrotli
-	case "xz":
-		if strings.ToLower(format) == "tar" {
-			tarUseXz = true
-		} else {
-			compType = compXZ
-		}
-	case "none":
-		features.Set(fNoCompress)
-		compType = compGzip
-	default:
-		log.Fatalf("Unknown compression: %s", compression)
-	}
-
-	switch strings.ToLower(speedOpt) {
-	case "fastest":
-		compSpeed = SpeedFastest
-	case "default":
-		compSpeed = SpeedDefault
-	case "better":
-		compSpeed = SpeedBetterCompression
-	case "best":
-		compSpeed = SpeedBestCompression
-	default:
-		log.Fatalf("Unknown speed: %s", speedOpt)
-	}
-
-	switch strings.ToLower(sumOpt) {
-	case "crc32":
-		checksumType = sumCRC32
-		checksumLength = 4
-	case "crc16":
-		checksumType = sumCRC16
-		checksumLength = 2
-	case "xxhash":
-		checksumType = sumXXHash
-		checksumLength = 8
-	case "sha256":
-		checksumType = sumSHA256
-		checksumLength = 32
-	case "blake3":
-		checksumType = sumBlake3
-		checksumLength = 32
-	default:
-		log.Fatalf("Unknown checksum: %s", sumOpt)
-	}
-
-	if cmdLetter == 'c' && !hasKnownArchiveExt(archivePath) {
-		if strings.ToLower(format) == "tar" {
-			if features.IsNotSet(fNoCompress) {
-				if tarUseXz {
-					archivePath += ".tar.xz"
-				} else {
-					archivePath += ".tar.gz"
-				}
-			} else {
-				archivePath += ".tar"
-			}
-		} else {
-			archivePath += ".goxa"
-		}
-	}
-
-	//Modes
-	switch cmdLetter {
-	case 'c':
-		if strings.ToLower(format) == "tar" {
-			if err := createTar(flagSet.Args()); err != nil {
-				log.Fatalf("tar create failed: %v", err)
-			}
-			return
-		}
-		create(flagSet.Args())
-	case 'l':
-		if strings.ToLower(format) == "tar" {
-			log.Fatalf("list not supported for tar format")
-		}
-		extract(flagSet.Args(), true, false)
-	case 'j':
-		if strings.ToLower(format) == "tar" {
-			log.Fatalf("list not supported for tar format")
-		}
-		extract(flagSet.Args(), true, true)
-	case 'x':
-		if archivePath == defaultArchiveName {
-			log.Fatal("You must specify an archive to extract.")
-		}
-		if len(flagSet.Args()) > 0 {
-			if features.IsSet(fAbsolutePaths) {
-				log.Fatal("Destination specified in conjunction with absolute path mode, stopping.")
-			}
-		}
-		if strings.ToLower(format) == "tar" {
-			dest := ""
-			if len(flagSet.Args()) > 0 {
-				dest = flagSet.Args()[0]
-			}
-			if err := extractTar(dest); err != nil {
-				log.Fatalf("tar extract failed: %v", err)
-			}
-			return
-		}
-		extract(flagSet.Args(), false, false)
-	default:
-		showUsage()
-		doLog(false, "Unknown mode: %c", cmd[0])
-		return
-	}
+	runMode(cmdLetter, flagSet.Args(), mflags.format)
 }
 
 func showUsage() {
@@ -370,4 +123,316 @@ func showUsage() {
 	fmt.Println("  goxa c -arc=backup.tar.gz dir/                # create tar.gz")
 	fmt.Println("  goxa c -arc=backup.goxa.b64 dir/              # Base64 encoded archive")
 	fmt.Println("  goxa c -arc=backup.goxaf dir/                 # FEC encoded archive")
+}
+
+type flagSettings struct {
+	sel       string
+	format    string
+	speedOpt  string
+	sumOpt    string
+	fecData   int
+	fecParity int
+	fecLevel  string
+	showVer   bool
+}
+
+func startProfile() func() {
+	if !makeProfile {
+		return func() {}
+	}
+	f, err := os.Create("perf.pprof")
+	if err != nil {
+		log.Fatalf("could not create CPU profile: %v", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		log.Fatalf("could not start CPU profile: %v", err)
+	}
+	return func() {
+		pprof.StopCPUProfile()
+		f.Close()
+	}
+}
+
+func handleTopLevel(args []string) bool {
+	fs := flag.NewFlagSet("goxa", flag.ExitOnError)
+	var showVer bool
+	var showHelp bool
+	var pgo bool
+	fs.BoolVar(&showVer, "version", false, "print version and exit")
+	fs.BoolVar(&showHelp, "help", false, "show help")
+	fs.BoolVar(&showHelp, "h", false, "show help")
+	fs.BoolVar(&pgo, "pgo", false, "run PGO training and exit")
+	fs.Parse(args)
+	if showVer {
+		fmt.Println("goxa v" + appVersion)
+		return true
+	}
+	if pgo {
+		runPGOTraining()
+		return true
+	}
+	if showHelp {
+		showUsage()
+		return true
+	}
+	showUsage()
+	return true
+}
+
+func parseCommand(cmd string) (byte, string) {
+	cmd = strings.ToLower(cmd)
+	if cmd == "" {
+		return 0, ""
+	}
+	letter := cmd[0]
+	opts := ""
+	if len(cmd) > 1 {
+		opts = cmd[1:]
+	}
+	return letter, opts
+}
+
+func initFlags() (*flag.FlagSet, *flagSettings) {
+	fs := flag.NewFlagSet("goxa", flag.ExitOnError)
+	f := &flagSettings{}
+	fs.StringVar(&archivePath, "arc", defaultArchiveName, "archive file name (extension not required)")
+	fs.BoolVar(&toStdOut, "stdout", false, "output archive data to stdout")
+	fs.BoolVar(&progress, "progress", true, "show progress bar")
+	fs.BoolVar(&interactiveMode, "interactive", true, "prompt when archive uses extra flags")
+	fs.StringVar(&compression, "comp", "zstd", "compression: gzip|zstd|lz4|s2|snappy|brotli|xz|none")
+	fs.StringVar(&f.speedOpt, "speed", "fastest", "compression speed: fastest|default|better|best")
+	fs.StringVar(&f.sumOpt, "sum", "blake3", "checksum: crc32|crc16|xxhash|sha256|blake3")
+	fs.StringVar(&f.format, "format", "goxa", "archive format: tar|goxa")
+	fs.StringVar(&f.sel, "files", "", "comma-separated list of files and directories to extract")
+	fs.IntVar(&f.fecData, "fec-data", fecDataShards, "FEC data shards")
+	fs.IntVar(&f.fecParity, "fec-parity", fecParityShards, "FEC parity shards")
+	fs.StringVar(&f.fecLevel, "fec-level", "", "FEC redundancy preset: low|medium|high")
+	fs.IntVar(&fileRetries, "retries", 3, "retries when file changes during read (0=never give up)")
+	fs.IntVar(&fileRetryDelay, "retrydelay", 5, "delay between retries in seconds")
+	fs.BoolVar(&failOnChange, "failonchange", false, "treat file change after retries as fatal")
+	fs.BoolVar(&bombCheck, "bombcheck", true, "detect extremely compressed files")
+	fs.BoolVar(&spaceCheck, "spacecheck", true, "verify free disk space before operations")
+	fs.BoolVar(&noFlush, "noflush", false, "skip final disk flush")
+	fs.BoolVar(&f.showVer, "version", false, "print version and exit")
+	return fs, f
+}
+
+func configureFEC(f *flagSettings) {
+	switch f.fecLevel {
+	case "low":
+		fecDataShards, fecParityShards = 10, 3
+	case "medium":
+		fecDataShards, fecParityShards = 8, 4
+	case "high":
+		fecDataShards, fecParityShards = 5, 5
+	case "":
+		fecDataShards = f.fecData
+		fecParityShards = f.fecParity
+	default:
+		log.Fatalf("invalid fec-level: %s", f.fecLevel)
+	}
+}
+
+func detectArchiveFormat(cmdLetter byte, format string) string {
+	detFmt, noComp := detectFormatFromExt(archivePath)
+	if detFmt != "" {
+		format = detFmt
+		if detFmt == "tar" {
+			if noComp {
+				features.Set(fNoCompress)
+			} else {
+				features.Clear(fNoCompress)
+			}
+		}
+	}
+
+	if cmdLetter != 'c' {
+		if fFmt, fNoComp, ok := detectFormatFromHeader(archivePath); ok {
+			format = fFmt
+			if fFmt == "tar" {
+				if fNoComp {
+					features.Set(fNoCompress)
+				} else {
+					features.Clear(fNoCompress)
+				}
+			}
+		}
+	}
+	return format
+}
+
+func buildExtractList(sel string) {
+	if sel == "" {
+		return
+	}
+	parts := strings.Split(sel, ",")
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		extractList = append(extractList, filepath.Clean(p))
+	}
+}
+
+func applyModeOptions(opts string) {
+	for _, letter := range opts {
+		switch letter {
+		case 'a':
+			features.Set(fAbsolutePaths)
+		case 'p':
+			features.Set(fPermissions)
+		case 'm':
+			features.Set(fModDates)
+		case 's':
+			features.Clear(fChecksums)
+		case 'b':
+			features.Set(fChecksums)
+			features.Set(fBlockChecksums)
+		case 'n':
+			features.Set(fNoCompress)
+		case 'i':
+			features.Set(fIncludeInvis)
+		case 'o':
+			features.Set(fSpecialFiles)
+		case 'u':
+			useArchiveFlags = true
+		case 'v':
+			verboseMode = true
+		case 'f':
+			doForce = true
+		default:
+			continue
+		}
+	}
+}
+
+func configureCompression(format string) {
+	switch strings.ToLower(compression) {
+	case "gzip":
+		compType = compGzip
+	case "zstd":
+		compType = compZstd
+	case "lz4":
+		compType = compLZ4
+	case "s2":
+		compType = compS2
+	case "snappy":
+		compType = compSnappy
+	case "brotli":
+		compType = compBrotli
+	case "xz":
+		if strings.ToLower(format) == "tar" {
+			tarUseXz = true
+		} else {
+			compType = compXZ
+		}
+	case "none":
+		features.Set(fNoCompress)
+		compType = compGzip
+	default:
+		log.Fatalf("Unknown compression: %s", compression)
+	}
+}
+
+func configureSpeed(speed string) {
+	switch strings.ToLower(speed) {
+	case "fastest":
+		compSpeed = SpeedFastest
+	case "default":
+		compSpeed = SpeedDefault
+	case "better":
+		compSpeed = SpeedBetterCompression
+	case "best":
+		compSpeed = SpeedBestCompression
+	default:
+		log.Fatalf("Unknown speed: %s", speed)
+	}
+}
+
+func configureChecksum(sum string) {
+	switch strings.ToLower(sum) {
+	case "crc32":
+		checksumType = sumCRC32
+		checksumLength = 4
+	case "crc16":
+		checksumType = sumCRC16
+		checksumLength = 2
+	case "xxhash":
+		checksumType = sumXXHash
+		checksumLength = 8
+	case "sha256":
+		checksumType = sumSHA256
+		checksumLength = 32
+	case "blake3":
+		checksumType = sumBlake3
+		checksumLength = 32
+	default:
+		log.Fatalf("Unknown checksum: %s", sum)
+	}
+}
+
+func ensureArchiveExtension(cmdLetter byte, format string) {
+	if cmdLetter != 'c' || hasKnownArchiveExt(archivePath) {
+		return
+	}
+	if strings.ToLower(format) == "tar" {
+		if features.IsNotSet(fNoCompress) {
+			if tarUseXz {
+				archivePath += ".tar.xz"
+			} else {
+				archivePath += ".tar.gz"
+			}
+		} else {
+			archivePath += ".tar"
+		}
+	} else {
+		archivePath += ".goxa"
+	}
+}
+
+func runMode(cmdLetter byte, args []string, format string) {
+	switch cmdLetter {
+	case 'c':
+		if strings.ToLower(format) == "tar" {
+			if err := createTar(args); err != nil {
+				log.Fatalf("tar create failed: %v", err)
+			}
+			return
+		}
+		create(args)
+	case 'l':
+		if strings.ToLower(format) == "tar" {
+			log.Fatalf("list not supported for tar format")
+		}
+		extract(args, true, false)
+	case 'j':
+		if strings.ToLower(format) == "tar" {
+			log.Fatalf("list not supported for tar format")
+		}
+		extract(args, true, true)
+	case 'x':
+		if archivePath == defaultArchiveName {
+			log.Fatal("You must specify an archive to extract.")
+		}
+		if len(args) > 0 {
+			if features.IsSet(fAbsolutePaths) {
+				log.Fatal("Destination specified in conjunction with absolute path mode, stopping.")
+			}
+		}
+		if strings.ToLower(format) == "tar" {
+			dest := ""
+			if len(args) > 0 {
+				dest = args[0]
+			}
+			if err := extractTar(dest); err != nil {
+				log.Fatalf("tar extract failed: %v", err)
+			}
+			return
+		}
+		extract(args, false, false)
+	default:
+		showUsage()
+		doLog(false, "Unknown mode: %c", cmdLetter)
+	}
 }

--- a/test-goxa.sh
+++ b/test-goxa.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Re-run this script with bash if not already using bash
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec bash "$0" "$@"
+fi
+
 set -euo pipefail
 
 # Extensive end-to-end testing of goxa covering many CLI combinations.


### PR DESCRIPTION
## Summary
- split up `main` into smaller helpers
- handle top level flags and archive logic in dedicated functions

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684bab8475a4832aabbb214b6d6e815f