### PR TITLE
Add -block option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A fast, portable archiving utility written in Go.
 GoXA is conservative by default. Archives only store relative paths by default and hidden files are skipped unless `i` is specified. Checksums use fast but strong Blake3 hashes. Existing files are never overwritten unless the `f` flag is given. Zip bombs and free space are checked automatically. The
 progress display is enabled for all interactive runs and the program prompts when an archive was created with extra flags so you can confirm them. You always supply the archive name with `-arc` to avoid surprises.
 
-Data is written in large 512KiB blocks for high throughput. Each archive ends with a trailer that records the offset of every block so readers can jump directly to any part of any file. The block system is designed for future multi-threaded readers and writers. Work on threading will begin once goxa is feature-complete and reasonably tested.
+Data is written in large 512KiB blocks for high throughput (adjustable with `-block`). Each archive ends with a trailer that records the offset of every block so readers can jump directly to any part of any file. The block system is designed for future multi-threaded readers and writers. Work on threading will begin once goxa is feature-complete and reasonably tested.
 
 ## Installation
 
@@ -105,6 +105,7 @@ When extracting, the program prompts if the archive was created with flags you d
 | `-comp` | compression algorithm |
 | `-speed` | compression speed level |
 | `-sum` | checksum algorithm (crc32, crc16, xxhash, sha256, blake3) |
+| `-block` | compression block size in bytes |
 | `-format` | force `goxa` or `tar` format |
 | `-retries` | retries when a file changes during read |
 | `-retrydelay` | seconds to wait between retries |

--- a/goxa.1
+++ b/goxa.1
@@ -25,7 +25,7 @@ files are never overwritten unless \fBf\fP is given. The program checks for zip
 bombs and available space and prompts when extra archive flags are detected.
 Progress output is on by default and the archive name must be provided with
 \fB-arc\fP.
-Data blocks default to 512KiB and each archive ends with a trailer listing block
+Data blocks default to 512KiB (set with \fB-block\fP) and each archive ends with a trailer listing block
 offsets for fast seeking.
 .SH MODES
 .TP
@@ -98,6 +98,9 @@ Compression speed: fastest, default, better or best.
 .TP
 .BI -sum " ALG"
 Checksum algorithm: crc32, crc16, xxhash, sha256 or blake3.
+.TP
+.BI -block " N"
+Compression block size in bytes.
 .TP
 .BI -format " TYPE"
 Force archive format: goxa or tar.

--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 
 const makeProfile = false
 
+var flagBlockSize uint = defaultBlockSize
+
 func main() {
 	defer startProfile()()
 
@@ -37,6 +39,7 @@ func main() {
 
 	flagSet, mflags := initFlags()
 	flagSet.Parse(os.Args[2:])
+	blockSize = uint32(flagBlockSize)
 
 	quietMode = toStdOut || cmdLetter == 'j'
 	if quietMode {
@@ -94,6 +97,7 @@ func showUsage() {
 	fmt.Println("  -comp ALG       compression algorithm (gzip, zstd, lz4, s2, snappy, brotli, xz, none)")
 	fmt.Println("  -speed LEVEL    compression speed (fastest, default, better, best)")
 	fmt.Println("  -sum ALG        checksum algorithm (crc32, crc16, xxhash, sha256, blake3)")
+	fmt.Println("  -block N        compression block size in bytes")
 	fmt.Println("  -format FORMAT  archive format (goxa or tar)")
 	fmt.Println("  -retries N      retries when file changes during read (0 = never give up)")
 	fmt.Println("  -retrydelay N   delay between retries in seconds")
@@ -202,6 +206,7 @@ func initFlags() (*flag.FlagSet, *flagSettings) {
 	fs.StringVar(&compression, "comp", "zstd", "compression: gzip|zstd|lz4|s2|snappy|brotli|xz|none")
 	fs.StringVar(&f.speedOpt, "speed", "fastest", "compression speed: fastest|default|better|best")
 	fs.StringVar(&f.sumOpt, "sum", "blake3", "checksum: crc32|crc16|xxhash|sha256|blake3")
+	fs.UintVar(&flagBlockSize, "block", defaultBlockSize, "compression block size in bytes")
 	fs.StringVar(&f.format, "format", "goxa", "archive format: tar|goxa")
 	fs.StringVar(&f.sel, "files", "", "comma-separated list of files and directories to extract")
 	fs.IntVar(&f.fecData, "fec-data", fecDataShards, "FEC data shards")


### PR DESCRIPTION
## Summary
- support custom block size with `-block`
- document new flag in README and man page

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684bb1d4412c832a8f244914ba144c5f