### PR TITLE
Update FEC docs with redundancy percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ Appending `.b32` or `.b64` to the archive file encodes the archive in Base32 or 
 For example, with `-fec-data=10 -fec-parity=3` the archive is split into 13 shards. Any 10 shards are enough to fully recover the data. Presets are:
 
 ```
-low    -> 10 data / 3 parity
-medium -> 8 data / 4 parity
-high   -> 5 data / 5 parity
+low    -> 10 data / 3 parity  (~30% redundancy)
+medium -> 8 data / 4 parity   (50% redundancy)
+high   -> 5 data / 5 parity   (100% redundancy)
 ```
 
 Examples:

--- a/goxa.1
+++ b/goxa.1
@@ -140,7 +140,7 @@ Number of FEC data shards (default 10).
 Number of FEC parity shards (default 3).
 .TP
 .BI -fec-level " LEVEL"
-FEC redundancy preset: \fBlow\fP (10 data / 3 parity), \fBmedium\fP (8 data / 4 parity) or \fBhigh\fP (5 data / 5 parity). Use of \fB-fec-data\fP and \fB-fec-parity\fP overrides these presets.
+FEC redundancy preset: \fBlow\fP (10 data / 3 parity \(ap30% redundancy\)), \fBmedium\fP (8 data / 4 parity \(50% redundancy\)) or \fBhigh\fP (5 data / 5 parity \(100% redundancy\)). Use of \fB-fec-data\fP and \fB-fec-parity\fP overrides these presets.
 .SS FEC ENCODING
 FEC archives use Reed-Solomon coding to provide redundancy. Data shards contain the original bytes while parity shards allow recovery from missing or corrupted shards. For example, \fB-fec-data=10\fP and \fB-fec-parity=3\fP create 13 shards; any 10 shards are sufficient to reconstruct the archive. The \fB.goxaf\fP extension triggers automatic decoding during extraction or listing.
 .SS BASE32 AND BASE64

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func showUsage() {
 	fmt.Println("  -pgo            run built-in PGO training (10k files ~2GB, s-curve around 150KB)")
 	fmt.Println("  -fec-data N     number of FEC data shards (default 10)")
 	fmt.Println("  -fec-parity N   number of FEC parity shards (default 3)")
-	fmt.Println("  -fec-level L    FEC redundancy preset (low, medium, high)")
+	fmt.Println("  -fec-level L    FEC redundancy preset: low (~30%), medium (~50%), high (~100%)")
 
 	fmt.Println()
 	fmt.Println("Extensions:")
@@ -213,7 +213,7 @@ func initFlags() (*flag.FlagSet, *flagSettings) {
 	fs.StringVar(&f.sel, "files", "", "comma-separated list of files and directories to extract")
 	fs.IntVar(&f.fecData, "fec-data", fecDataShards, "FEC data shards")
 	fs.IntVar(&f.fecParity, "fec-parity", fecParityShards, "FEC parity shards")
-	fs.StringVar(&f.fecLevel, "fec-level", "", "FEC redundancy preset: low|medium|high")
+	fs.StringVar(&f.fecLevel, "fec-level", "", "FEC redundancy preset: low(~30%)|medium(~50%)|high(~100%)")
 	fs.IntVar(&fileRetries, "retries", 3, "retries when file changes during read (0=never give up)")
 	fs.IntVar(&fileRetryDelay, "retrydelay", 5, "delay between retries in seconds")
 	fs.BoolVar(&failOnChange, "failonchange", false, "treat file change after retries as fatal")


### PR DESCRIPTION
## Summary
- document percent redundancy for FEC levels in README
- show FEC redundancy percentages in main help text and flag description
- explain FEC redundancy in the `goxa.1` man page

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684bbcb1b010832abeb4efd8f9c28d92