### PR TITLE
Add threads flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ When extracting, the program prompts if the archive was created with flags you d
 | `-bombcheck=false` | disable zip bomb detection |
 | `-spacecheck=false` | disable free space check |
 | `-noflush` | skip final disk flush |
+| `-threads` | number of threads to use |
 | `-version` | print program version |
 | `-pgo` | run built-in PGO training (10k files \~2GB total, s-curve around 150KB) |
 | `-fec-data` | number of FEC data shards |

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io/fs"
+	"runtime"
 	"time"
 )
 
@@ -31,6 +32,7 @@ var (
 	bombCheck                                bool   = true
 	spaceCheck                               bool   = true
 	noFlush                                  bool   = false
+	threads                                  int    = runtime.NumCPU()
 )
 
 type FileEntry struct {

--- a/goxa.1
+++ b/goxa.1
@@ -127,6 +127,9 @@ Disable free space check.
 .B -noflush
 Skip final disk flush.
 .TP
+.BI -threads " N"
+Number of threads to use.
+.TP
 .B -version
 Print program version and exit.
 .TP

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"runtime/pprof"
 
 	"path/filepath"
@@ -106,6 +107,7 @@ func showUsage() {
 	fmt.Println("  -bombcheck=false disable zip bomb detection")
 	fmt.Println("  -spacecheck=false disable free space check")
 	fmt.Println("  -noflush        skip final disk flush")
+	fmt.Println("  -threads N      number of threads to use")
 	fmt.Println("  -version        print program version")
 	fmt.Println("  -pgo            run built-in PGO training (10k files ~2GB, s-curve around 150KB)")
 	fmt.Println("  -fec-data N     number of FEC data shards (default 10)")
@@ -220,6 +222,7 @@ func initFlags() (*flag.FlagSet, *flagSettings) {
 	fs.BoolVar(&bombCheck, "bombcheck", true, "detect extremely compressed files")
 	fs.BoolVar(&spaceCheck, "spacecheck", true, "verify free disk space before operations")
 	fs.BoolVar(&noFlush, "noflush", false, "skip final disk flush")
+	fs.IntVar(&threads, "threads", runtime.NumCPU(), "number of threads to use")
 	fs.BoolVar(&f.showVer, "version", false, "print version and exit")
 	return fs, f
 }


### PR DESCRIPTION
## Summary
- add `-threads` flag and option to configuration
- document thread usage in README and man page

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684bbb1b780c832a87ade652b6dfc870