### PR TITLE
Fix default extraction directory creation

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -143,6 +143,9 @@ func extract(destinations []string, listOnly bool, jsonList bool) {
 		archiveName := path.Base(archivePath)
 		archiveName = stripArchiveExt(archiveName)
 		destination = path.Clean(pwd + "/" + archiveName + "/")
+		if destination != "" {
+			os.Mkdir(destination, os.ModePerm)
+		}
 	}
 
 	//Create reader


### PR DESCRIPTION
## Summary
- create the default destination directory when not provided by user

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`


------
https://chatgpt.com/codex/tasks/task_e_684bce24305c832a9786e7b9ed3616c7