### PR TITLE
Dynamic buffer size and asynchronous writes

### DIFF
--- a/const.go
+++ b/const.go
@@ -1,5 +1,7 @@
 package main
 
+import "runtime"
+
 const (
 	magic         = "GOXA"
 	appVersion    = "0.0.92"
@@ -14,7 +16,7 @@ const (
 )
 
 var (
-	readBuffer  = int(defaultBlockSize) * 4
+	readBuffer  = int(defaultBlockSize) * 4 * runtime.NumCPU()
 	writeBuffer = readBuffer
 )
 

--- a/const.go
+++ b/const.go
@@ -1,7 +1,5 @@
 package main
 
-import "runtime"
-
 const (
 	magic         = "GOXA"
 	appVersion    = "0.0.92"
@@ -16,7 +14,7 @@ const (
 )
 
 var (
-	readBuffer  = int(defaultBlockSize) * 4 * runtime.NumCPU()
+	readBuffer  = int(defaultBlockSize) * 3
 	writeBuffer = readBuffer
 )
 

--- a/const.go
+++ b/const.go
@@ -5,14 +5,17 @@ const (
 	appVersion    = "0.0.92"
 	protoVersion2 = 2
 
-	readBuffer         = 1000 * 1000 * 1 //MiB
-	writeBuffer        = readBuffer
 	defaultArchiveName = "archive.goxa"
 	defaultBlockSize   = 512 * 1024 // 512KiB
 	// fat32SpanSize is used when -span is specified without a value.
 	fat32SpanSize = 4*1024*1024*1024 - 64*1024 // 4GiB - 64KiB
 	// defaultSpanSize disables spanning by default (max int64).
 	defaultSpanSize = int64(^uint64(0) >> 1)
+)
+
+var (
+	readBuffer  = int(defaultBlockSize) * 4
+	writeBuffer = readBuffer
 )
 
 // Checksum types

--- a/create.go
+++ b/create.go
@@ -108,6 +108,13 @@ func compressor(w io.Writer) io.WriteCloser {
 
 func create(inputPaths []string) error {
 
+	if features.IsSet(fNoCompress) {
+		blockSize = 0
+	} else if blockSize == 0 {
+		blockSize = defaultBlockSize
+	}
+	updateBuffers()
+
 	var bf *BufferedFile
 	var tmpPath string
 	var outFile fileLike

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func main() {
 	args := preprocessSpan(os.Args[2:])
 	flagSet.Parse(args)
 	blockSize = uint32(flagBlockSize)
+	updateBuffers()
 
 	quietMode = toStdOut || cmdLetter == 'j'
 	if quietMode {

--- a/util.go
+++ b/util.go
@@ -21,9 +21,8 @@ import (
 )
 
 func updateBuffers() {
-	workers := runtime.NumCPU()
 	if blockSize > 0 {
-		readBuffer = int(blockSize) * 4 * workers
+		readBuffer = int(blockSize) * 3
 	} else {
 		readBuffer = 1000 * 1000 // 1MiB
 	}

--- a/util.go
+++ b/util.go
@@ -20,6 +20,15 @@ import (
 	"github.com/ulikunitz/xz"
 )
 
+func updateBuffers() {
+	if blockSize > 0 {
+		readBuffer = int(blockSize) * 4
+	} else {
+		readBuffer = 1000 * 1000 // 1MiB
+	}
+	writeBuffer = readBuffer
+}
+
 func fileExists(filePath string) (bool, error) {
 	_, err := os.Stat(filePath)
 	if err == nil {

--- a/util.go
+++ b/util.go
@@ -21,8 +21,9 @@ import (
 )
 
 func updateBuffers() {
+	workers := runtime.NumCPU()
 	if blockSize > 0 {
-		readBuffer = int(blockSize) * 4
+		readBuffer = int(blockSize) * 4 * workers
 	} else {
 		readBuffer = 1000 * 1000 // 1MiB
 	}


### PR DESCRIPTION
## Summary
- compute buffer sizes based on `blockSize`
- update buffers when creating or reading archives
- add `WriteAt` to `BufferedFile`
- use asynchronous block writes when checksums are disabled

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684bcc5a235c832aa1aa424cdf2f41b9