### PR TITLE
Optimize compression concurrency

### DIFF
--- a/create.go
+++ b/create.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -38,7 +39,7 @@ func compressor(w io.Writer) io.WriteCloser {
 		case SpeedBestCompression:
 			level = zstd.SpeedBestCompression
 		}
-		zw, err := zstd.NewWriter(w, zstd.WithEncoderLevel(level))
+		zw, err := zstd.NewWriter(w, zstd.WithEncoderLevel(level), zstd.WithEncoderConcurrency(runtime.NumCPU()))
 		if err != nil {
 			log.Fatalf("zstd init failed: %v", err)
 		}

--- a/extract.go
+++ b/extract.go
@@ -3,10 +3,10 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"compress/gzip"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	gzip "github.com/klauspost/pgzip"
 	"io"
 	"io/fs"
 	"log"
@@ -31,7 +31,7 @@ import (
 func decompressor(r io.Reader, cType uint8) (io.ReadCloser, error) {
 	switch cType {
 	case compZstd:
-		zr, err := zstd.NewReader(r)
+		zr, err := zstd.NewReader(r, zstd.WithDecoderConcurrency(runtime.NumCPU()))
 		if err != nil {
 			return nil, err
 		}

--- a/tar.go
+++ b/tar.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"archive/tar"
-	"compress/gzip"
+	gzip "github.com/klauspost/pgzip"
 	"io"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
## Summary
- improve zstd compression and extraction by using all CPU cores
- switch gzip handling to pgzip for faster threaded I/O

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c4a11a018832a95ae79155a081ea1