### PR TITLE
Add threads flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A fast, portable archiving utility written in Go.
 GoXA is conservative by default. Archives only store relative paths by default and hidden files are skipped unless `i` is specified. Checksums use fast but strong Blake3 hashes. Existing files are never overwritten unless the `f` flag is given. Zip bombs and free space are checked automatically. The
 progress display is enabled for all interactive runs and the program prompts when an archive was created with extra flags so you can confirm them. You always supply the archive name with `-arc` to avoid surprises.
 
-Data is written in large 512KiB blocks for high throughput (adjustable with `-block`). Each archive ends with a trailer that records the offset of every block so readers can jump directly to any part of any file. The block system is designed for future multi-threaded readers and writers. Work on threading will begin once goxa is feature-complete and reasonably tested.
+Data is written in large 512KiB blocks for high throughput (adjustable with `-block`). Each archive ends with a trailer that records the offset of every block so readers can jump directly to any part of any file. The block system supports multi-threaded readers and writers; set the desired concurrency with `-threads`.
 
 ## Installation
 
@@ -106,6 +106,7 @@ When extracting, the program prompts if the archive was created with flags you d
 | `-speed` | compression speed level |
 | `-sum` | checksum algorithm (crc32, crc16, xxhash, sha256, blake3) |
 | `-block` | compression block size in bytes |
+| `-threads` | number of threads to use |
 | `-format` | force `goxa` or `tar` format |
 | `-retries` | retries when a file changes during read |
 | `-retrydelay` | seconds to wait between retries |

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io/fs"
+	"runtime"
 	"time"
 )
 
@@ -22,6 +23,7 @@ var (
 	extractList                              []string
 	protoVersion                             uint16 = protoVersion2
 	blockSize                                uint32 = defaultBlockSize
+	threads                                  int    = runtime.NumCPU()
 	fecDataShards                            int    = 10
 	fecParityShards                          int    = 3
 	fileRetries                              int    = 3

--- a/create.go
+++ b/create.go
@@ -38,7 +38,10 @@ func compressor(w io.Writer) io.WriteCloser {
 		case SpeedBestCompression:
 			level = zstd.SpeedBestCompression
 		}
-		zw, err := zstd.NewWriter(w, zstd.WithEncoderLevel(level))
+		if threads < 1 {
+			threads = 1
+		}
+		zw, err := zstd.NewWriter(w, zstd.WithEncoderLevel(level), zstd.WithEncoderConcurrency(threads))
 		if err != nil {
 			log.Fatalf("zstd init failed: %v", err)
 		}
@@ -100,6 +103,10 @@ func compressor(w io.Writer) io.WriteCloser {
 		if err != nil {
 			log.Fatalf("gzip init: %v", err)
 		}
+		if threads < 1 {
+			threads = 1
+		}
+		_ = zw.SetConcurrency(1<<20, threads)
 		return zw
 	}
 }

--- a/extract.go
+++ b/extract.go
@@ -3,17 +3,16 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"compress/gzip"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	gzip "github.com/klauspost/pgzip"
 	"io"
 	"io/fs"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -31,7 +30,10 @@ import (
 func decompressor(r io.Reader, cType uint8) (io.ReadCloser, error) {
 	switch cType {
 	case compZstd:
-		zr, err := zstd.NewReader(r)
+		if threads < 1 {
+			threads = 1
+		}
+		zr, err := zstd.NewReader(r, zstd.WithDecoderConcurrency(threads))
 		if err != nil {
 			return nil, err
 		}
@@ -51,7 +53,10 @@ func decompressor(r io.Reader, cType uint8) (io.ReadCloser, error) {
 		}
 		return io.NopCloser(xr), nil
 	default:
-		gr, err := gzip.NewReader(r)
+		if threads < 1 {
+			threads = 1
+		}
+		gr, err := gzip.NewReaderN(r, 0, threads)
 		if err != nil {
 			return nil, err
 		}
@@ -569,7 +574,10 @@ func extract(destinations []string, listOnly bool, jsonList bool) {
 	arc.Close()
 
 	if lfeat.IsNotSet(fNoCompress) {
-		wg := sizedwaitgroup.New(runtime.NumCPU())
+		if threads < 1 {
+			threads = 1
+		}
+		wg := sizedwaitgroup.New(threads)
 		for f := range fileList {
 			if !isSelected(fileList[f].Path) {
 				continue

--- a/goxa.1
+++ b/goxa.1
@@ -27,6 +27,8 @@ Progress output is on by default and the archive name must be provided with
 \fB-arc\fP.
 Data blocks default to 512KiB (set with \fB-block\fP) and each archive ends with a trailer listing block
 offsets for fast seeking.
+The \fB-threads\fP option controls how many goroutines are used for
+compression and extraction.
 .SH MODES
 .TP
 .B c
@@ -101,6 +103,9 @@ Checksum algorithm: crc32, crc16, xxhash, sha256 or blake3.
 .TP
 .BI -block " N"
 Compression block size in bytes.
+.TP
+.BI -threads " N"
+Number of threads to use.
 .TP
 .BI -format " TYPE"
 Force archive format: goxa or tar.

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"runtime/pprof"
 
 	"path/filepath"
@@ -98,6 +99,7 @@ func showUsage() {
 	fmt.Println("  -speed LEVEL    compression speed (fastest, default, better, best)")
 	fmt.Println("  -sum ALG        checksum algorithm (crc32, crc16, xxhash, sha256, blake3)")
 	fmt.Println("  -block N        compression block size in bytes")
+	fmt.Println("  -threads N      number of threads to use")
 	fmt.Println("  -format FORMAT  archive format (goxa or tar)")
 	fmt.Println("  -retries N      retries when file changes during read (0 = never give up)")
 	fmt.Println("  -retrydelay N   delay between retries in seconds")
@@ -207,6 +209,7 @@ func initFlags() (*flag.FlagSet, *flagSettings) {
 	fs.StringVar(&f.speedOpt, "speed", "fastest", "compression speed: fastest|default|better|best")
 	fs.StringVar(&f.sumOpt, "sum", "blake3", "checksum: crc32|crc16|xxhash|sha256|blake3")
 	fs.UintVar(&flagBlockSize, "block", defaultBlockSize, "compression block size in bytes")
+	fs.IntVar(&threads, "threads", runtime.NumCPU(), "number of threads to use")
 	fs.StringVar(&f.format, "format", "goxa", "archive format: tar|goxa")
 	fs.StringVar(&f.sel, "files", "", "comma-separated list of files and directories to extract")
 	fs.IntVar(&f.fecData, "fec-data", fecDataShards, "FEC data shards")

--- a/tar.go
+++ b/tar.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"archive/tar"
-	"compress/gzip"
+	gzip "github.com/klauspost/pgzip"
 	"io"
 	"os"
 	"path/filepath"
@@ -33,6 +33,10 @@ func createTar(paths []string) error {
 			defer xzw.Close()
 		} else {
 			gw := gzip.NewWriter(f)
+			if threads < 1 {
+				threads = 1
+			}
+			_ = gw.SetConcurrency(1<<20, threads)
 			w = gw
 			defer f.Close()
 			defer gw.Close()
@@ -121,7 +125,10 @@ func extractTar(destination string) error {
 			}
 			src = xr
 		} else {
-			gr, err := gzip.NewReader(r)
+			if threads < 1 {
+				threads = 1
+			}
+			gr, err := gzip.NewReaderN(r, 0, threads)
 			if err != nil {
 				r.Close()
 				return err


### PR DESCRIPTION
## Summary
- introduce `-threads` option for compression and extraction concurrency
- apply threads to zstd and pgzip writer/reader operations
- support threaded extraction via sized wait group
- document threads option in help, README and man page

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c4a11a018832a95ae79155a081ea1