### PR TITLE
Improve archive reader efficiency

### DIFF
--- a/extract_test.go
+++ b/extract_test.go
@@ -25,7 +25,9 @@ func TestExtractFileDirCreationFailure(t *testing.T) {
 
 	item := FileEntry{Path: filepath.Join("sub", "file.txt"), Offset: 1}
 
-	_ = extractFile(archivePath, destFile+string(os.PathSeparator), 0, compGzip, &item, &progressData{})
+	f, _ := os.Open(archivePath)
+	defer f.Close()
+	_ = extractFile(f, destFile+string(os.PathSeparator), 0, compGzip, &item, &progressData{})
 
 	if _, err := os.Stat(filepath.Join(tmp, "destfile", "sub")); err == nil {
 		t.Fatalf("directory should not be created")


### PR DESCRIPTION
## Summary
- share the archive file descriptor across workers in `extract`
- use `io.NewSectionReader` to avoid reopening the archive for each file
- adjust tests for new `extractFile` signature

## Testing
- `go vet ./...`
- `go test ./...`
- `./test-goxa.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c53ce6600832a9a20fed6853544ab